### PR TITLE
chore: support py3.13

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1964,5 +1964,5 @@ propcache = ">=0.2.0"
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.10 <3.13"
-content-hash = "b42499699aebc2b358cf22a4e7196a13d0cf428d4997fbefd51b62876a6046fa"
+python-versions = ">=3.10 <3.14"
+content-hash = "094c636c655bd5e8571ea63cd563b9a9eebe10af4ccc65f9ea930fe5cac81bba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.10 <3.13"
+python = ">=3.10 <3.14"
 cloup = "^3.0"
 textual =  "^0.83"
 confluent-kafka = {extras = ["avro", "json", "protobuf"], version = "^2.6"}


### PR DESCRIPTION
bump the project to allow building with py3.13

relates to https://github.com/Homebrew/homebrew-core/pull/193861