### PR TITLE
feat: add Textual theme support

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -18,6 +18,16 @@ kaskade consumer -b my-kafka:9092 -t my-json-topic -k json -v json
 
 Supported deserializers: `bytes`, `boolean`, `string`, `long`, `integer`, `double`, `float`, `json`, `avro`, `protobuf`, and `registry`.
 
+### Themes
+
+Kaskade defaults to the `eva01` Unit-01-inspired theme. Choose any Textual theme at launch:
+
+```bash
+kaskade admin -b my-kafka:9092 --theme dracula
+```
+
+While Kaskade is running, press `Ctrl+P` and select a theme from the command palette. Palette choices apply only to the current session.
+
 ### Consume from the beginning
 
 ```bash

--- a/kaskade/admin.py
+++ b/kaskade/admin.py
@@ -1,19 +1,23 @@
-from itertools import cycle
 from typing import Any, ClassVar
 
 from confluent_kafka import KafkaException
 from confluent_kafka.cimpl import NewTopic
-from rich.table import Table
 from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Container
 from textual.screen import ModalScreen
-from textual.widget import Widget
-from textual.widgets import DataTable, Input, RadioButton, RadioSet
+from textual.widgets import (
+    DataTable,
+    Footer,
+    Input,
+    RadioButton,
+    RadioSet,
+    TabbedContent,
+    TabPane,
+)
 
-from kaskade.banner import KaskadeBanner
-from kaskade.colors import PRIMARY, SECONDARY
+from kaskade.colors import PRIMARY
 from kaskade.configs import (
     CLEANUP_POLICY_CONFIG,
     MILLISECONDS_1W,
@@ -25,15 +29,14 @@ from kaskade.services import (
     TopicService,
 )
 from kaskade.themes import KaskadeApp
-from kaskade.unicodes import APPROXIMATION, PIPE
-from kaskade.utils import notify_error
+from kaskade.unicodes import APPROXIMATION
+from kaskade.utils import make_it_async, notify_error
 
 REFRESH_TABLE_DELAY = 1
 FILTER_TOPICS_SHORTCUT = "ctrl+f"
 BACK_SHORTCUT = "escape"
 ALL_TOPICS_SHORTCUT = BACK_SHORTCUT
 SUBMIT_SHORTCUT = "enter"
-NEXT_SHORTCUT = "tab"
 SAVE_SHORTCUT = "ctrl+s"
 DESCRIBE_TOPIC_SHORTCUT = SUBMIT_SHORTCUT
 NEW_TOPIC_SHORTCUT = "ctrl+n"
@@ -43,45 +46,26 @@ REFRESH_TOPICS_SHORTCUT = "ctrl+r"
 QUIT_SHORTCUT = "ctrl+q"
 
 
-class AdminShortcuts(Widget):
-    SHORTCUTS: ClassVar[list[list[str]]] = [
-        ["describe:", f"<{SUBMIT_SHORTCUT}>", PIPE, "edit:", f"<{EDIT_TOPIC_SHORTCUT}>"],
-        ["refresh:", f"<{REFRESH_TOPICS_SHORTCUT}>", PIPE, "create:", f"<{NEW_TOPIC_SHORTCUT}>"],
-        ["filter:", f"<{FILTER_TOPICS_SHORTCUT}>", PIPE, "show all:", f"<{BACK_SHORTCUT}>"],
-        ["delete:", f"<{DELETE_TOPIC_SHORTCUT}>", PIPE, "quit:", f"<{QUIT_SHORTCUT}>"],
+class FilterTopicsScreen(ModalScreen[str]):
+    BINDING_GROUP_TITLE = "Filter Topics"
+    AUTO_FOCUS = "#topic-filter"
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding(
+            BACK_SHORTCUT,
+            "close",
+            "Back",
+            tooltip="Close the filter without applying it.",
+            id="kaskade.filter-topics.close",
+        )
     ]
 
-    def render(self) -> Table:
-        table = Table(box=None, show_header=False, padding=(0, 0, 0, 1))
-        table.add_column(style=PRIMARY)
-        table.add_column(style=SECONDARY)
-        table.add_column(style=SECONDARY)
-        table.add_column(style=PRIMARY)
-        table.add_column(style=SECONDARY)
-
-        for shortcuts in self.SHORTCUTS:
-            table.add_row(*shortcuts)
-
-        return table
-
-
-class Header(Widget):
-
     def compose(self) -> ComposeResult:
-        yield AdminShortcuts()
-        yield KaskadeBanner(include_version=True, include_slogan=False)
-
-
-class FilterTopicsScreen(ModalScreen[str]):
-    BINDINGS: ClassVar[list[BindingType]] = [Binding(BACK_SHORTCUT, "close")]
-
-    def compose(self) -> ComposeResult:
-        input_filter = Input(placeholder="word to match")
-        input_filter.border_title = f"[{PRIMARY}]filter topics[/]"
-        input_filter.border_subtitle = (
-            f"[{PRIMARY}]filter:[/] <{SUBMIT_SHORTCUT}> | [{PRIMARY}]back:[/] <{BACK_SHORTCUT}>"
+        input_filter = Input(
+            id="topic-filter", placeholder="Topic name contains…", classes="kaskade-input"
         )
+        input_filter.border_title = f"[{PRIMARY}]Filter Topics[/]"
         yield input_filter
+        yield Footer(compact=True)
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         self.dismiss(event.value)
@@ -91,87 +75,110 @@ class FilterTopicsScreen(ModalScreen[str]):
 
 
 class DeleteTopicScreen(ModalScreen[bool]):
-    BINDINGS: ClassVar[list[BindingType]] = [Binding(BACK_SHORTCUT, "cancel")]
+    BINDING_GROUP_TITLE = "Delete Topic"
+    AUTO_FOCUS = "#topic-confirmation"
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding(
+            BACK_SHORTCUT,
+            "cancel",
+            "Cancel",
+            tooltip="Keep the topic and close this confirmation.",
+            id="kaskade.delete-topic.cancel",
+        )
+    ]
 
     def __init__(self, topic: Topic):
         super().__init__()
         self.topic = topic
 
     def compose(self) -> ComposeResult:
-        label = Input(placeholder="type the topic's name")
-        label.border_title = rf"[{PRIMARY}]delete topic[/] \[[{PRIMARY}]{self.topic}[/]]"
-        label.border_subtitle = (
-            f"[{PRIMARY}]delete:[/] <{SUBMIT_SHORTCUT}> | [{PRIMARY}]cancel:[/] <{BACK_SHORTCUT}>"
+        label = Input(
+            id="topic-confirmation",
+            placeholder="Type the topic name to confirm",
+            classes="kaskade-input",
         )
+        label.border_title = rf"[{PRIMARY}]Delete Topic[/] \[[{PRIMARY}]{self.topic}[/]]"
         yield label
+        yield Footer(compact=True)
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         if self.topic.name == event.value:
             self.dismiss(True)
         else:
-            self.notify("type the name of the topic", title="confirmation step", severity="warning")
+            self.notify(
+                "Type the topic name exactly to confirm deletion.",
+                title="Confirmation Required",
+                severity="warning",
+            )
 
     def action_cancel(self) -> None:
         self.dismiss(False)
 
 
 class DescribeTopicScreen(ModalScreen):
+    BINDING_GROUP_TITLE = "Topic Details"
+    AUTO_FOCUS = "Tabs"
     BINDINGS: ClassVar[list[BindingType]] = [
-        Binding(BACK_SHORTCUT, "close"),
-        Binding(NEXT_SHORTCUT, "next"),
+        Binding(
+            BACK_SHORTCUT,
+            "close",
+            "Back",
+            tooltip="Close the topic details.",
+            id="kaskade.describe-topic.close",
+        )
     ]
 
     def __init__(self, topic: Topic):
         super().__init__()
         self.topic = topic
-        self.tabs = cycle(["partitions", "groups", "group members"])
 
     def compose(self) -> ComposeResult:
-        table: DataTable = DataTable()
+        with TabbedContent(initial="partitions", id="topic-details"):
+            with TabPane("Partitions", id="partitions"):
+                yield self._partitions_table()
+            with TabPane("Groups", id="groups"):
+                yield self._groups_table()
+            with TabPane("Group Members", id="group-members"):
+                yield self._group_members_table()
+        yield Footer(compact=True)
+
+    def _new_table(self, table_id: str, count: int, item_name: str) -> DataTable:
+        table: DataTable = DataTable(id=table_id, classes="kaskade-table details-table")
         table.cursor_type = "row"
         table.zebra_stripes = True
-        table.border_subtitle = (
-            f"[{PRIMARY}]next tab:[/] <{NEXT_SHORTCUT}> | [{PRIMARY}]back:[/] <{BACK_SHORTCUT}>"
-        )
-        yield table
+        table.border_title = rf"[{PRIMARY}]{self.topic}[/] \[[{PRIMARY}]{count} {item_name}[/]]"
+        return table
 
-    def on_mount(self) -> None:
-        self.action_next()
-
-    def render_partitions(self) -> None:
-        table = self.query_one(DataTable)
-        table.clear(columns=True)
-        table.border_title = rf"[{PRIMARY}]partitions[/] | groups | group members \[[{PRIMARY}]{self.topic}[/]]\[[{PRIMARY}]{self.topic.partitions_count()}[/]]"
-        table.add_column("id")
-        table.add_column("leader")
-        table.add_column("isrs")
-        table.add_column("replicas")
-        table.add_column("records")
+    def _partitions_table(self) -> DataTable:
+        table = self._new_table("partitions-table", self.topic.partitions_count(), "Partitions")
+        table.add_column("ID")
+        table.add_column("Leader")
+        table.add_column("ISRs")
+        table.add_column("Replicas")
+        table.add_column("Records")
 
         for partition in self.topic.partitions:
-            row = [
+            table.add_row(
                 str(partition.id),
                 str(partition.leader),
                 str(partition.isrs),
                 str(partition.replicas),
                 str(partition.records_count()),
-            ]
-            table.add_row(*row)
+            )
+        return table
 
-    def render_groups(self) -> None:
-        table = self.query_one(DataTable)
-        table.clear(columns=True)
-        table.border_title = rf"partitions | [{PRIMARY}]groups[/] | group members \[[{PRIMARY}]{self.topic}[/]]\[[{PRIMARY}]{self.topic.groups_count()}[/]]"
-        table.add_column("id")
-        table.add_column("coordinator")
-        table.add_column("state")
-        table.add_column("assignor")
-        table.add_column("partitions")
-        table.add_column("members")
-        table.add_column("lag")
+    def _groups_table(self) -> DataTable:
+        table = self._new_table("groups-table", self.topic.groups_count(), "Groups")
+        table.add_column("ID")
+        table.add_column("Coordinator")
+        table.add_column("State")
+        table.add_column("Assignor")
+        table.add_column("Partitions")
+        table.add_column("Members")
+        table.add_column("Lag")
 
         for group in self.topic.groups:
-            row = [
+            table.add_row(
                 group.id,
                 str(group.coordinator) if group.coordinator else "",
                 group.state,
@@ -179,44 +186,52 @@ class DescribeTopicScreen(ModalScreen):
                 str(group.partitions_count()),
                 str(group.members_count()),
                 str(group.lag_count()),
-            ]
-            table.add_row(*row)
+            )
+        return table
 
-    def render_group_members(self) -> None:
-        table = self.query_one(DataTable)
-        table.clear(columns=True)
-        table.border_title = rf"partitions | groups | [{PRIMARY}]group members[/] \[[{PRIMARY}]{self.topic}[/]]\[[{PRIMARY}]{self.topic.group_members_count()}[/]]"
-        table.add_column("group")
-        table.add_column("client id")
-        table.add_column("member id")
-        table.add_column("host")
-        table.add_column("assignment")
+    def _group_members_table(self) -> DataTable:
+        table = self._new_table(
+            "group-members-table", self.topic.group_members_count(), "Group Members"
+        )
+        table.add_column("Group")
+        table.add_column("Client ID")
+        table.add_column("Member ID")
+        table.add_column("Host")
+        table.add_column("Assignment")
 
         for group in self.topic.groups:
             for member in group.members:
-                row = [
+                table.add_row(
                     member.group,
                     member.client_id,
                     member.id,
                     member.host,
                     str(member.assignment),
-                ]
-                table.add_row(*row)
-
-    def action_next(self) -> None:
-        current_tab = next(self.tabs)
-        method_name = current_tab.replace(" ", "_")
-        render_table = getattr(self, f"render_{method_name}")
-        render_table()
+                )
+        return table
 
     def action_close(self) -> None:
         self.dismiss()
 
 
 class EditTopicScreen(ModalScreen[bool]):
+    BINDING_GROUP_TITLE = "Edit Topic"
+    AUTO_FOCUS = "#partitions"
     BINDINGS: ClassVar[list[BindingType]] = [
-        Binding(BACK_SHORTCUT, "back"),
-        Binding(SAVE_SHORTCUT, "edit"),
+        Binding(
+            BACK_SHORTCUT,
+            "back",
+            "Back",
+            tooltip="Close the editor without saving changes.",
+            id="kaskade.edit-topic.close",
+        ),
+        Binding(
+            SAVE_SHORTCUT,
+            "edit",
+            "Save Changes",
+            tooltip="Apply the edited Kafka topic configuration.",
+            id="kaskade.edit-topic.save",
+        ),
     ]
 
     def __init__(
@@ -235,25 +250,29 @@ class EditTopicScreen(ModalScreen[bool]):
         self.retention = retention
 
     def compose(self) -> ComposeResult:
-        input_partitions = Input(id="partitions", type="integer", value=self.partitions)
-        input_partitions.border_title = "partitions"
+        input_partitions = Input(
+            id="partitions", type="integer", value=self.partitions, classes="kaskade-input"
+        )
+        input_partitions.border_title = "Partitions"
 
         input_min_insync = Input(
-            id="min_insync_replicas", type="integer", value=self.min_insync_replicas
+            id="min_insync_replicas",
+            type="integer",
+            value=self.min_insync_replicas,
+            classes="kaskade-input",
         )
-        input_min_insync.border_title = "min insync replicas"
+        input_min_insync.border_title = "Min In-Sync Replicas"
 
-        input_retention = Input(id="retention", type="integer", value=self.retention)
-        input_retention.border_title = "retention (ms)"
-
-        radio_set = RadioSet(id="cleanup")
-        radio_set.border_title = "cleanup policy"
-
-        container = Container()
-        container.border_title = rf"[{PRIMARY}]edit topic[/] \[[{PRIMARY}]{self.topic_name}[/]]"
-        container.border_subtitle = (
-            f"[{PRIMARY}]save:[/] <{SAVE_SHORTCUT}> | [{PRIMARY}]back:[/] <{BACK_SHORTCUT}>"
+        input_retention = Input(
+            id="retention", type="integer", value=self.retention, classes="kaskade-input"
         )
+        input_retention.border_title = "Retention (ms)"
+
+        radio_set = RadioSet(id="cleanup", classes="kaskade-radio")
+        radio_set.border_title = "Cleanup Policy"
+
+        container = Container(classes="topic-form")
+        container.border_title = rf"[{PRIMARY}]Edit Topic[/] \[[{PRIMARY}]{self.topic_name}[/]]"
 
         with container:
             yield input_partitions
@@ -268,6 +287,7 @@ class EditTopicScreen(ModalScreen[bool]):
                     str(CleanupPolicy.COMPACT),
                     value=self.cleanup_policy == str(CleanupPolicy.COMPACT),
                 )
+        yield Footer(compact=True)
 
     def action_edit(self) -> None:
         partitions_input = self.query_one("#partitions", Input)
@@ -293,35 +313,59 @@ class EditTopicScreen(ModalScreen[bool]):
 
 
 class CreateTopicScreen(ModalScreen[NewTopic]):
+    BINDING_GROUP_TITLE = "Create Topic"
+    AUTO_FOCUS = "#name"
     BINDINGS: ClassVar[list[BindingType]] = [
-        Binding(BACK_SHORTCUT, "back"),
-        Binding(SAVE_SHORTCUT, "create"),
+        Binding(
+            BACK_SHORTCUT,
+            "back",
+            "Back",
+            tooltip="Close the form without creating a topic.",
+            id="kaskade.create-topic.close",
+        ),
+        Binding(
+            SAVE_SHORTCUT,
+            "create",
+            "Create Topic",
+            tooltip="Create the topic with the configured values.",
+            id="kaskade.create-topic.save",
+        ),
     ]
 
     def compose(self) -> ComposeResult:
-        input_name = Input(id="name", placeholder="alphanumerics, '.', '_' and '-'")
-        input_name.border_title = "name"
-
-        input_partitions = Input(id="partitions", type="integer", value="1")
-        input_partitions.border_title = "partitions"
-
-        input_replication = Input(id="replicas", type="integer", value="3")
-        input_replication.border_title = "replicas"
-
-        input_min_insync = Input(id="min_insync_replicas", type="integer", value="2")
-        input_min_insync.border_title = "min insync replicas"
-
-        input_retention = Input(id="retention", type="integer", value=f"{MILLISECONDS_1W}")
-        input_retention.border_title = "retention (ms)"
-
-        radio_set = RadioSet(id="cleanup")
-        radio_set.border_title = "cleanup policy"
-
-        container = Container()
-        container.border_title = f"[{PRIMARY}]create topic[/]"
-        container.border_subtitle = (
-            f"[{PRIMARY}]create:[/] <{SAVE_SHORTCUT}> | [{PRIMARY}]back:[/] <{BACK_SHORTCUT}>"
+        input_name = Input(
+            id="name",
+            placeholder="Letters, numbers, '.', '_' and '-'",
+            classes="kaskade-input",
         )
+        input_name.border_title = "Name"
+
+        input_partitions = Input(
+            id="partitions", type="integer", value="1", classes="kaskade-input"
+        )
+        input_partitions.border_title = "Partitions"
+
+        input_replication = Input(id="replicas", type="integer", value="3", classes="kaskade-input")
+        input_replication.border_title = "Replicas"
+
+        input_min_insync = Input(
+            id="min_insync_replicas", type="integer", value="2", classes="kaskade-input"
+        )
+        input_min_insync.border_title = "Min In-Sync Replicas"
+
+        input_retention = Input(
+            id="retention",
+            type="integer",
+            value=f"{MILLISECONDS_1W}",
+            classes="kaskade-input",
+        )
+        input_retention.border_title = "Retention (ms)"
+
+        radio_set = RadioSet(id="cleanup", classes="kaskade-radio")
+        radio_set.border_title = "Cleanup Policy"
+
+        container = Container(classes="topic-form")
+        container.border_title = f"[{PRIMARY}]Create Topic[/]"
 
         with container:
             yield input_name
@@ -332,6 +376,7 @@ class CreateTopicScreen(ModalScreen[NewTopic]):
             with radio_set:
                 yield RadioButton(str(CleanupPolicy.DELETE), value=True)
                 yield RadioButton(str(CleanupPolicy.COMPACT))
+        yield Footer(compact=True)
 
     def action_create(self) -> None:
         name_input = self.query_one("#name", Input)
@@ -374,14 +419,61 @@ class CreateTopicScreen(ModalScreen[NewTopic]):
 
 
 class ListTopics(Container):
+    BINDING_GROUP_TITLE = "Topics"
     BINDINGS: ClassVar[list[BindingType]] = [
-        Binding(FILTER_TOPICS_SHORTCUT, "filter"),
-        Binding(ALL_TOPICS_SHORTCUT, "all"),
-        Binding(REFRESH_TOPICS_SHORTCUT, "refresh"),
-        Binding(DELETE_TOPIC_SHORTCUT, "delete"),
-        Binding(NEW_TOPIC_SHORTCUT, "new"),
-        Binding(EDIT_TOPIC_SHORTCUT, "edit"),
-        Binding(DESCRIBE_TOPIC_SHORTCUT, "describe", priority=True),
+        Binding(
+            DESCRIBE_TOPIC_SHORTCUT,
+            "describe",
+            "Describe",
+            priority=True,
+            tooltip="Show partitions, groups, and members for the selected topic.",
+            id="kaskade.topics.describe",
+        ),
+        Binding(
+            FILTER_TOPICS_SHORTCUT,
+            "filter",
+            "Filter",
+            tooltip="Filter topics by name.",
+            id="kaskade.topics.filter",
+        ),
+        Binding(
+            REFRESH_TOPICS_SHORTCUT,
+            "refresh",
+            "Refresh",
+            tooltip="Reload topic metadata from Kafka.",
+            id="kaskade.topics.refresh",
+        ),
+        Binding(
+            NEW_TOPIC_SHORTCUT,
+            "new",
+            "Create",
+            tooltip="Open the topic creation form.",
+            id="kaskade.topics.create",
+        ),
+        Binding(
+            EDIT_TOPIC_SHORTCUT,
+            "edit",
+            "Edit",
+            show=False,
+            tooltip="Edit the selected topic configuration.",
+            id="kaskade.topics.edit",
+        ),
+        Binding(
+            DELETE_TOPIC_SHORTCUT,
+            "delete",
+            "Delete",
+            show=False,
+            tooltip="Delete the selected topic after confirmation.",
+            id="kaskade.topics.delete",
+        ),
+        Binding(
+            ALL_TOPICS_SHORTCUT,
+            "all",
+            "Show All",
+            show=False,
+            tooltip="Clear the active topic filter.",
+            id="kaskade.topics.show-all",
+        ),
     ]
 
     def __init__(self, topic_service: TopicService):
@@ -392,40 +484,42 @@ class ListTopics(Container):
         self.current_filter: str | None = None
 
     def compose(self) -> ComposeResult:
-        table: DataTable = DataTable()
+        table: DataTable = DataTable(id="topics-table", classes="kaskade-table main-table")
         table.cursor_type = "row"
-        table.border_title = rf"[{PRIMARY}]topics[/] \[[{PRIMARY}]0[/]]"
-        table.border_subtitle = rf"\[[{PRIMARY}]admin mode[/]]"
+        table.border_title = rf"[{PRIMARY}]Topics[/] \[[{PRIMARY}]0[/]]"
+        table.border_subtitle = rf"\[[{PRIMARY}]Admin Mode[/]]"
         table.zebra_stripes = True
 
-        table.add_column("name")
-        table.add_column("partitions", width=10)
-        table.add_column("replicas", width=10)
-        table.add_column("in sync", width=10)
-        table.add_column("groups", width=10)
-        table.add_column("members", width=10)
-        table.add_column("records", width=10)
-        table.add_column("lag", width=10)
+        table.add_column("Name")
+        table.add_column("Partitions", width=10)
+        table.add_column("Replicas", width=10)
+        table.add_column("In Sync", width=10)
+        table.add_column("Groups", width=10)
+        table.add_column("Members", width=10)
+        table.add_column("Records", width=10)
+        table.add_column("Lag", width=10)
 
         yield table
 
     def on_mount(self) -> None:
+        self.query_one("#topics-table", DataTable).focus()
         self.action_refresh()
 
     def on_data_table_row_highlighted(self, data: DataTable.RowHighlighted) -> None:
         if data.row_key.value is None:
             return
         self.current_topic = self.topics.get(data.row_key.value)
+        self.refresh_bindings()
 
     async def refresh_table(self) -> None:
         try:
             self.topics = await self.topic_service.all()
         except KafkaException as ex:
-            notify_error(self.app, "kafka error", ex)
+            notify_error(self.app, "Kafka Error", ex)
 
         self.fill_table()
 
-    @work
+    @work(exclusive=True, group="topics-refresh")
     async def action_refresh(self) -> None:
         self.start_loading_table()
         await self.refresh_table()
@@ -434,16 +528,25 @@ class ListTopics(Container):
         def on_dismiss(result: NewTopic | None) -> None:
             if result is None:
                 return
-
-            self.start_loading_table()
-
-            try:
-                self.topic_service.create([result])
-                self.set_timer(REFRESH_TABLE_DELAY, self.refresh_table)
-            except KafkaException as ex:
-                notify_error(self.app, "kafka error", ex)
+            self.create_topic(result)
 
         self.app.push_screen(CreateTopicScreen(), on_dismiss)
+
+    @work(exclusive=True, group="topic-mutation")
+    async def create_topic(self, topic: NewTopic) -> None:
+        """Create a topic without blocking Textual's message loop."""
+        self.start_loading_table()
+        try:
+            await make_it_async(self.topic_service.create, [topic])
+            self.app.notify(
+                f"Created topic '{topic.topic}'.",
+                title="Topic Created",
+                severity="information",
+            )
+            self.set_timer(REFRESH_TABLE_DELAY, self.refresh_table)
+        except KafkaException as ex:
+            self.finish_loading_table()
+            notify_error(self.app, "Kafka Error", ex)
 
     def start_loading_table(self) -> None:
         table = self.query_one(DataTable)
@@ -453,18 +556,28 @@ class ListTopics(Container):
         table = self.query_one(DataTable)
         table.loading = False
 
-    def action_edit(self) -> None:
+    @work(exclusive=True, group="topic-config")
+    async def action_edit(self) -> None:
         if self.current_topic is None:
             return
 
-        topic_configs = self.topic_service.get_configs(self.current_topic.name)
+        topic = self.current_topic
+        self.start_loading_table()
+        try:
+            topic_configs = await make_it_async(self.topic_service.get_configs, topic.name)
+        except KafkaException as ex:
+            self.finish_loading_table()
+            notify_error(self.app, "Kafka Error", ex)
+            return
+        self.finish_loading_table()
+
         min_insync_replicas = topic_configs.get(MIN_INSYNC_REPLICAS_CONFIG)
         cleanup_policy = topic_configs.get(CLEANUP_POLICY_CONFIG)
         retention = topic_configs.get(RETENTION_MS_CONFIG)
 
         edit_topic_screen = EditTopicScreen(
-            self.current_topic.name,
-            str(self.current_topic.partitions_count()),
+            topic.name,
+            str(topic.partitions_count()),
             min_insync_replicas if min_insync_replicas else "",
             cleanup_policy if cleanup_policy else "",
             retention if retention else "",
@@ -473,53 +586,66 @@ class ListTopics(Container):
         def on_dismiss(result: bool | None) -> None:
             if not result:
                 return
-
-            if self.current_topic is None:
-                return
-
-            self.start_loading_table()
-
-            try:
-                if int(edit_topic_screen.partitions) - self.current_topic.partitions_count() > 0:
-                    self.topic_service.add_partitions(
-                        self.current_topic.name, int(edit_topic_screen.partitions)
-                    )
-
-                self.topic_service.edit(
-                    self.current_topic.name,
-                    {
-                        MIN_INSYNC_REPLICAS_CONFIG: edit_topic_screen.min_insync_replicas,
-                        CLEANUP_POLICY_CONFIG: edit_topic_screen.cleanup_policy,
-                        RETENTION_MS_CONFIG: edit_topic_screen.retention,
-                    },
-                )
-
-                self.set_timer(REFRESH_TABLE_DELAY, self.refresh_table)
-            except (KafkaException, ValueError) as ex:
-                notify_error(self.app, "kafka error", ex)
+            self.update_topic(topic, edit_topic_screen)
 
         self.app.push_screen(edit_topic_screen, on_dismiss)
+
+    @work(exclusive=True, group="topic-mutation")
+    async def update_topic(self, topic: Topic, editor: EditTopicScreen) -> None:
+        """Update a topic without blocking Textual's message loop."""
+        self.start_loading_table()
+        try:
+            partition_count = int(editor.partitions)
+            if partition_count > topic.partitions_count():
+                await make_it_async(self.topic_service.add_partitions, topic.name, partition_count)
+
+            await make_it_async(
+                self.topic_service.edit,
+                topic.name,
+                {
+                    MIN_INSYNC_REPLICAS_CONFIG: editor.min_insync_replicas,
+                    CLEANUP_POLICY_CONFIG: editor.cleanup_policy,
+                    RETENTION_MS_CONFIG: editor.retention,
+                },
+            )
+            self.app.notify(
+                f"Updated topic '{topic.name}'.",
+                title="Topic Updated",
+                severity="information",
+            )
+            self.set_timer(REFRESH_TABLE_DELAY, self.refresh_table)
+        except (KafkaException, ValueError) as ex:
+            self.finish_loading_table()
+            notify_error(self.app, "Kafka Error", ex)
 
     def action_delete(self) -> None:
         if self.current_topic is None:
             return
 
+        topic = self.current_topic
+
         def on_dismiss(result: bool | None) -> None:
             if not result:
                 return
+            self.delete_topic(topic)
 
-            if self.current_topic is None:
-                return
+        self.app.push_screen(DeleteTopicScreen(topic), on_dismiss)
 
-            self.start_loading_table()
-
-            try:
-                self.topic_service.delete(self.current_topic.name)
-                self.set_timer(REFRESH_TABLE_DELAY, self.refresh_table)
-            except KafkaException as ex:
-                notify_error(self.app, "kafka error", ex)
-
-        self.app.push_screen(DeleteTopicScreen(self.current_topic), on_dismiss)
+    @work(exclusive=True, group="topic-mutation")
+    async def delete_topic(self, topic: Topic) -> None:
+        """Delete a topic without blocking Textual's message loop."""
+        self.start_loading_table()
+        try:
+            await make_it_async(self.topic_service.delete, topic.name)
+            self.app.notify(
+                f"Deleted topic '{topic.name}'.",
+                title="Topic Deleted",
+                severity="information",
+            )
+            self.set_timer(REFRESH_TABLE_DELAY, self.refresh_table)
+        except KafkaException as ex:
+            self.finish_loading_table()
+            notify_error(self.app, "Kafka Error", ex)
 
     def action_describe(self) -> None:
         if self.current_topic is None:
@@ -537,9 +663,19 @@ class ListTopics(Container):
 
         self.app.push_screen(FilterTopicsScreen(), on_dismiss)
 
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        """Disable contextual actions when their required state is unavailable."""
+        if action in {"delete", "describe", "edit"}:
+            return self.current_topic is not None
+        if action == "all":
+            return self.current_filter is not None
+        return True
+
     def fill_table(self) -> None:
         table = self.query_one(DataTable)
         table.clear()
+        self.current_topic = None
+        self.refresh_bindings()
 
         total_count = 0
         for topic in self.topics.values():
@@ -562,14 +698,15 @@ class ListTopics(Container):
             rf"\[[{PRIMARY}]*{self.current_filter}*[/]]" if self.current_filter else ""
         )
         table.border_title = (
-            rf"[{PRIMARY}]topics[/] {border_title_filter_info}\[[{PRIMARY}]{total_count}[/]]"
+            rf"[{PRIMARY}]Topics[/] {border_title_filter_info}\[[{PRIMARY}]{total_count}[/]]"
         )
-        table.focus()
 
         self.finish_loading_table()
 
 
 class KaskadeAdmin(KaskadeApp):
+    TITLE = "Kaskade Admin"
+    AUTO_FOCUS = "#topics-table"
     CSS_PATH = "styles.css"
 
     def __init__(self, kafka_config: dict[str, Any]):
@@ -577,5 +714,5 @@ class KaskadeAdmin(KaskadeApp):
         self.kafka_config = kafka_config
 
     def compose(self) -> ComposeResult:
-        yield Header()
         yield ListTopics(TopicService(self.kafka_config))
+        yield Footer(compact=True)

--- a/kaskade/admin.py
+++ b/kaskade/admin.py
@@ -5,7 +5,7 @@ from confluent_kafka import KafkaException
 from confluent_kafka.cimpl import NewTopic
 from rich.table import Table
 from textual import work
-from textual.app import App, ComposeResult
+from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Container
 from textual.screen import ModalScreen
@@ -24,6 +24,7 @@ from kaskade.models import CleanupPolicy, Topic
 from kaskade.services import (
     TopicService,
 )
+from kaskade.themes import KaskadeApp
 from kaskade.unicodes import APPROXIMATION, PIPE
 from kaskade.utils import notify_error
 
@@ -568,13 +569,12 @@ class ListTopics(Container):
         self.finish_loading_table()
 
 
-class KaskadeAdmin(App):
+class KaskadeAdmin(KaskadeApp):
     CSS_PATH = "styles.css"
 
     def __init__(self, kafka_config: dict[str, Any]):
         super().__init__()
         self.kafka_config = kafka_config
-        self.use_command_palette = False
 
     def compose(self) -> ComposeResult:
         yield Header()

--- a/kaskade/colors.py
+++ b/kaskade/colors.py
@@ -1,2 +1,2 @@
-PRIMARY = "#af5fd7"
-SECONDARY = "#00af87"
+PRIMARY = "primary"
+SECONDARY = "secondary"

--- a/kaskade/consumer.py
+++ b/kaskade/consumer.py
@@ -1,17 +1,15 @@
 from typing import Any, ClassVar
 
 from confluent_kafka import KafkaException
-from rich.table import Table
 from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Container, ScrollableContainer
 from textual.screen import ModalScreen
-from textual.widget import Widget
-from textual.widgets import DataTable, Input, Label, ListItem, ListView, Pretty
+from textual.widgets import DataTable, Footer, Input, OptionList, Pretty
+from textual.widgets.option_list import Option
 
-from kaskade.banner import KaskadeBanner
-from kaskade.colors import PRIMARY, SECONDARY
+from kaskade.colors import PRIMARY
 from kaskade.deserializers import (
     DESERIALIZATION_EXCEPTIONS,
     Deserialization,
@@ -20,11 +18,10 @@ from kaskade.deserializers import (
 from kaskade.models import Record
 from kaskade.services import ConsumerService
 from kaskade.themes import KaskadeApp
-from kaskade.unicodes import PIPE
 from kaskade.utils import notify_error
 
 CHUNKS_SHORTCUT = "#"
-NEXT_SHORTCUT = "tab"
+NEXT_SHORTCUT = "n"
 QUIT_SHORTCUT = "ctrl+q"
 SUBMIT_SHORTCUT = "enter"
 BACK_SHORTCUT = "escape"
@@ -35,36 +32,18 @@ CONSUMER_EXCEPTIONS: tuple[type[Exception], ...] = (
 )
 
 
-class ConsumerShortcuts(Widget):
-    SHORTCUTS: ClassVar[list[list[str]]] = [
-        ["more:", f"<{NEXT_SHORTCUT}>", PIPE, "chunk:", f"<{CHUNKS_SHORTCUT}>"],
-        ["filter:", f"<{FILTER_SHORTCUT}>", PIPE, "show all:", f"<{BACK_SHORTCUT}>"],
-        ["show:", f"<{SUBMIT_SHORTCUT}>", PIPE, "quit:", f"<{QUIT_SHORTCUT}>"],
-    ]
-
-    def render(self) -> Table:
-        table = Table(box=None, show_header=False, padding=(0, 0, 0, 1))
-        table.add_column(style=PRIMARY)
-        table.add_column(style=SECONDARY)
-        table.add_column(style=SECONDARY)
-        table.add_column(style=PRIMARY)
-        table.add_column(style=SECONDARY)
-
-        for shortcuts in self.SHORTCUTS:
-            table.add_row(*shortcuts)
-
-        return table
-
-
-class Header(Widget):
-
-    def compose(self) -> ComposeResult:
-        yield ConsumerShortcuts()
-        yield KaskadeBanner(include_version=True, include_slogan=False)
-
-
 class FilterRecordScreen(ModalScreen[tuple[str, str, str, str]]):
-    BINDINGS: ClassVar[list[BindingType]] = [Binding(BACK_SHORTCUT, "back")]
+    BINDING_GROUP_TITLE = "Filter Records"
+    AUTO_FOCUS = "#key"
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding(
+            BACK_SHORTCUT,
+            "back",
+            "Back",
+            tooltip="Close the filter without applying it.",
+            id="kaskade.filter-records.close",
+        )
+    ]
 
     def __init__(self) -> None:
         super().__init__()
@@ -74,29 +53,34 @@ class FilterRecordScreen(ModalScreen[tuple[str, str, str, str]]):
         self.header_filter = ""
 
     def compose(self) -> ComposeResult:
-        input_key = Input(id="key", placeholder="word to match with keys")
-        input_key.border_title = "key"
+        input_key = Input(id="key", placeholder="Key contains…", classes="kaskade-input")
+        input_key.border_title = "Key"
 
-        input_value = Input(id="value", placeholder="word to match with values")
-        input_value.border_title = "value"
+        input_value = Input(id="value", placeholder="Value contains…", classes="kaskade-input")
+        input_value.border_title = "Value"
 
-        input_partition = Input(id="partition", placeholder="partition number", type="integer")
-        input_partition.border_title = "partition"
-
-        input_header = Input(id="header", placeholder="word to match with header values")
-        input_header.border_title = "header"
-
-        container = Container()
-        container.border_title = f"[{PRIMARY}]filter records[/]"
-        container.border_subtitle = (
-            f"[{PRIMARY}]filter:[/] <{SUBMIT_SHORTCUT}> | [{PRIMARY}]back:[/] <{BACK_SHORTCUT}>"
+        input_partition = Input(
+            id="partition",
+            placeholder="Partition number",
+            type="integer",
+            classes="kaskade-input",
         )
+        input_partition.border_title = "Partition"
+
+        input_header = Input(
+            id="header", placeholder="Header value contains…", classes="kaskade-input"
+        )
+        input_header.border_title = "Header"
+
+        container = Container(classes="record-filter")
+        container.border_title = f"[{PRIMARY}]Filter Records[/]"
 
         with container:
             yield input_key
             yield input_value
             yield input_partition
             yield input_header
+        yield Footer(compact=True)
 
     def on_input_submitted(self) -> None:
         input_key = self.query_one("#key", Input)
@@ -120,37 +104,59 @@ class FilterRecordScreen(ModalScreen[tuple[str, str, str, str]]):
 
 
 class ChunkSizeScreen(ModalScreen[int]):
-    BINDINGS: ClassVar[list[BindingType]] = [Binding(BACK_SHORTCUT, "close")]
+    BINDING_GROUP_TITLE = "Chunk Size"
+    AUTO_FOCUS = "#chunk-size"
+    CHUNK_SIZES = ("25", "50", "100", "500")
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding(
+            BACK_SHORTCUT,
+            "close",
+            "Back",
+            tooltip="Keep the current chunk size.",
+            id="kaskade.chunk-size.close",
+        )
+    ]
 
     def __init__(self, current_size: int):
         super().__init__()
         self.current_size = current_size
-        self.items = [ListItem(Label(size), name=size) for size in ("25", "50", "100", "500")]
 
     def _get_index(self, size: int) -> int:
-        for i, item in enumerate(self.items):
-            if item.name == str(size):
-                return i
-        return 0
+        try:
+            return self.CHUNK_SIZES.index(str(size))
+        except ValueError:
+            return 0
 
     def compose(self) -> ComposeResult:
-        view = ListView(*self.items, initial_index=self._get_index(self.current_size))
-        view.border_title = f"[{PRIMARY}]chunk size[/]"
-        view.border_subtitle = (
-            f"[{PRIMARY}]change:[/] <{SUBMIT_SHORTCUT}> | [{PRIMARY}]back:[/] <{BACK_SHORTCUT}>"
+        view = OptionList(
+            *(Option(size, id=size) for size in self.CHUNK_SIZES),
+            id="chunk-size",
+            compact=True,
         )
+        view.highlighted = self._get_index(self.current_size)
+        view.border_title = f"[{PRIMARY}]Chunk Size[/]"
         yield view
+        yield Footer(compact=True)
 
     def action_close(self) -> None:
         self.dismiss()
 
-    def on_list_view_selected(self, event: ListView.Selected) -> None:
-        chunk_size = int(event.item.name) if event.item.name is not None else self.current_size
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        chunk_size = int(event.option_id) if event.option_id is not None else self.current_size
         self.dismiss(chunk_size)
 
 
 class TopicScreen(ModalScreen):
-    BINDINGS: ClassVar[list[BindingType]] = [Binding(BACK_SHORTCUT, "close")]
+    BINDING_GROUP_TITLE = "Record Details"
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding(
+            BACK_SHORTCUT,
+            "close",
+            "Back",
+            tooltip="Close the record details.",
+            id="kaskade.record-details.close",
+        )
+    ]
 
     def __init__(self, topic: str, partition: int, offset: int, data: dict[str, Any]):
         super().__init__()
@@ -160,23 +166,56 @@ class TopicScreen(ModalScreen):
         self.record_offset = offset
 
     def compose(self) -> ComposeResult:
-        container = ScrollableContainer()
-        container.border_title = rf"[{PRIMARY}]record[/] \[[{PRIMARY}]{self.topic}[/]]\[[{PRIMARY}]{self.partition}[/]]\[[{PRIMARY}]{self.record_offset}[/]]"
-        container.border_subtitle = f"[{PRIMARY}]back:[/] <{BACK_SHORTCUT}>"
+        container = ScrollableContainer(classes="record-details")
+        container.border_title = rf"[{PRIMARY}]Record[/] \[[{PRIMARY}]{self.topic}[/]]\[[{PRIMARY}]{self.partition}[/]]\[[{PRIMARY}]{self.record_offset}[/]]"
         with container:
             yield Pretty(self.data)
+        yield Footer(compact=True)
 
     def action_close(self) -> None:
         self.dismiss()
 
 
 class ListRecords(Container):
+    BINDING_GROUP_TITLE = "Records"
     BINDINGS: ClassVar[list[BindingType]] = [
-        Binding(NEXT_SHORTCUT, "consume"),
-        Binding(CHUNKS_SHORTCUT, "change_chunk"),
-        Binding(FILTER_SHORTCUT, "filter"),
-        Binding(SUBMIT_SHORTCUT, "show_message", priority=True),
-        Binding(BACK_SHORTCUT, "all"),
+        Binding(
+            SUBMIT_SHORTCUT,
+            "show_message",
+            "Show Record",
+            priority=True,
+            tooltip="Open the complete selected record.",
+            id="kaskade.records.show",
+        ),
+        Binding(
+            NEXT_SHORTCUT,
+            "consume",
+            "Consume More",
+            tooltip="Consume the next chunk of Kafka records.",
+            id="kaskade.records.consume",
+        ),
+        Binding(
+            FILTER_SHORTCUT,
+            "filter",
+            "Filter",
+            tooltip="Filter records by key, value, partition, or header.",
+            id="kaskade.records.filter",
+        ),
+        Binding(
+            CHUNKS_SHORTCUT,
+            "change_chunk",
+            "Chunk Size",
+            tooltip="Change the number of records consumed at a time.",
+            id="kaskade.records.chunk-size",
+        ),
+        Binding(
+            BACK_SHORTCUT,
+            "all",
+            "Show All",
+            show=False,
+            tooltip="Clear all active record filters.",
+            id="kaskade.records.show-all",
+        ),
     ]
 
     def __init__(
@@ -200,6 +239,7 @@ class ListRecords(Container):
         self.value_filter = ""
         self.partition_filter = ""
         self.header_filter = ""
+        self._is_consuming = False
 
     def _new_consumer(self) -> ConsumerService:
         return ConsumerService(
@@ -228,21 +268,21 @@ class ListRecords(Container):
         if self.header_filter:
             title_filter += style(f"h:*{self.header_filter}*")
 
-        return rf"[{PRIMARY}]records[/] \[[{PRIMARY}]{self.topic}[/]]{title_filter}\[[{PRIMARY}]{len(self.records)}[/]]"
+        return rf"[{PRIMARY}]Records[/] \[[{PRIMARY}]{self.topic}[/]]{title_filter}\[[{PRIMARY}]{len(self.records)}[/]]"
 
     def compose(self) -> ComposeResult:
-        table: DataTable = DataTable()
+        table: DataTable = DataTable(id="records-table", classes="kaskade-table main-table")
         table.cursor_type = "row"
-        table.border_subtitle = rf"\[[{PRIMARY}]consumer mode[/]]"
+        table.border_subtitle = rf"\[[{PRIMARY}]Consumer Mode[/]]"
         table.zebra_stripes = True
         table.border_title = self._get_title()
 
-        table.add_column("key", width=30)
-        table.add_column("value", width=45)
-        table.add_column("datetime", width=23)
-        table.add_column("partition", width=9)
-        table.add_column("offset", width=9)
-        table.add_column("headers", width=9)
+        table.add_column("Key", width=30)
+        table.add_column("Value", width=45)
+        table.add_column("Timestamp", width=23)
+        table.add_column("Partition", width=9)
+        table.add_column("Offset", width=9)
+        table.add_column("Headers", width=9)
 
         yield table
 
@@ -250,6 +290,7 @@ class ListRecords(Container):
         self.consumer.close()
 
     def on_mount(self) -> None:
+        self.query_one("#records-table", DataTable).focus()
         self.action_consume()
 
     def action_all(self) -> None:
@@ -273,8 +314,11 @@ class ListRecords(Container):
     def _filter(self) -> None:
         table = self.query_one(DataTable)
         table.clear()
+        self.consumer.close()
         self.consumer = self._new_consumer()
         self.records = {}
+        self.current_record = None
+        self.refresh_bindings()
         table.border_title = self._get_title()
         self.action_consume()
 
@@ -299,16 +343,36 @@ class ListRecords(Container):
                 )
             )
         except DESERIALIZATION_EXCEPTIONS as ex:
-            notify_error(self.app, "deserialization error", ex)
+            notify_error(self.app, "Deserialization Error", ex)
 
     def on_data_table_row_highlighted(self, data: DataTable.RowHighlighted) -> None:
         if data.row_key is None or data.row_key.value is None:
             return
         self.current_record = self.records.get(data.row_key.value)
+        self.refresh_bindings()
 
-    @work
-    async def action_consume(self) -> None:
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        """Disable contextual actions when their required state is unavailable."""
+        if action == "show_message":
+            return self.current_record is not None
+        if action == "all":
+            return not self._is_consuming and any(
+                (self.key_filter, self.value_filter, self.partition_filter, self.header_filter)
+            )
+        if action in {"change_chunk", "consume", "filter"}:
+            return not self._is_consuming
+        return True
+
+    def action_consume(self) -> None:
+        """Start consuming unless a request is already running."""
+        if not self._is_consuming:
+            self.consume_records()
+
+    @work(group="records-consume")
+    async def consume_records(self) -> None:
         table = self.query_one(DataTable)
+        self._is_consuming = True
+        self.refresh_bindings()
         table.loading = True
 
         try:
@@ -333,13 +397,16 @@ class ListRecords(Container):
                 table.add_row(*row, key=record_id)
             table.border_title = self._get_title()
         except CONSUMER_EXCEPTIONS as ex:
-            notify_error(self.app, "error consuming records", ex)
-
-        table.loading = False
-        table.focus()
+            notify_error(self.app, "Consumption Error", ex)
+        finally:
+            table.loading = False
+            self._is_consuming = False
+            self.refresh_bindings()
 
 
 class KaskadeConsumer(KaskadeApp):
+    TITLE = "Kaskade Consumer"
+    AUTO_FOCUS = "#records-table"
     CSS_PATH = "styles.css"
 
     def __init__(
@@ -362,7 +429,6 @@ class KaskadeConsumer(KaskadeApp):
         self.value_deserialization = value_deserialization
 
     def compose(self) -> ComposeResult:
-        yield Header()
         yield ListRecords(
             self.topic,
             self.kafka_config,
@@ -370,3 +436,4 @@ class KaskadeConsumer(KaskadeApp):
             self.key_deserialization,
             self.value_deserialization,
         )
+        yield Footer(compact=True)

--- a/kaskade/consumer.py
+++ b/kaskade/consumer.py
@@ -106,7 +106,7 @@ class FilterRecordScreen(ModalScreen[tuple[str, str, str, str]]):
 class ChunkSizeScreen(ModalScreen[int]):
     BINDING_GROUP_TITLE = "Chunk Size"
     AUTO_FOCUS = "#chunk-size"
-    CHUNK_SIZES = ("25", "50", "100", "500")
+    CHUNK_SIZES = ("25", "50", "100", "500", "1000", "1500")
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding(
             BACK_SHORTCUT,

--- a/kaskade/consumer.py
+++ b/kaskade/consumer.py
@@ -1,11 +1,9 @@
 from typing import Any, ClassVar
 
 from confluent_kafka import KafkaException
-from rich.style import Style
 from rich.table import Table
-from rich.theme import Theme
 from textual import work
-from textual.app import App, ComposeResult
+from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Container, ScrollableContainer
 from textual.screen import ModalScreen
@@ -21,6 +19,7 @@ from kaskade.deserializers import (
 )
 from kaskade.models import Record
 from kaskade.services import ConsumerService
+from kaskade.themes import KaskadeApp
 from kaskade.unicodes import PIPE
 from kaskade.utils import notify_error
 
@@ -340,7 +339,7 @@ class ListRecords(Container):
         table.focus()
 
 
-class KaskadeConsumer(App):
+class KaskadeConsumer(KaskadeApp):
     CSS_PATH = "styles.css"
 
     def __init__(
@@ -354,7 +353,6 @@ class KaskadeConsumer(App):
         value_deserialization: Deserialization,
     ):
         super().__init__()
-        self.use_command_palette = False
         self.topic = topic
         self.kafka_config = kafka_config
         self.registry_config = registry_config
@@ -362,9 +360,6 @@ class KaskadeConsumer(App):
         self.avro_config = avro_config
         self.key_deserialization = key_deserialization
         self.value_deserialization = value_deserialization
-
-    def on_mount(self) -> None:
-        self.console.push_theme(Theme({"repr.str": Style(color=PRIMARY)}))
 
     def compose(self) -> ComposeResult:
         yield Header()

--- a/kaskade/main.py
+++ b/kaskade/main.py
@@ -16,6 +16,7 @@ from kaskade.configs import (
 )
 from kaskade.consumer import KaskadeConsumer
 from kaskade.deserializers import Deserialization
+from kaskade.themes import DEFAULT_THEME, available_theme_names
 from kaskade.utils import load_properties
 
 KAFKA_CONFIG_HELP = (
@@ -51,6 +52,13 @@ def cli() -> None:
 
 
 @cli.command(epilog=EPILOG_HELP)
+@cloup.option(
+    "--theme",
+    type=cloup.Choice(available_theme_names(), case_sensitive=False),
+    default=DEFAULT_THEME,
+    show_default=True,
+    help="Textual theme to use.",
+)
 @cloup.option_group(
     "Kafka options",
     cloup.option(
@@ -82,6 +90,7 @@ def admin(
     bootstrap_servers: str,
     kafka_config_file: str | None,
     kafka_config: dict[str, str],
+    theme: str,
 ) -> None:
     """
     Administrator mode.
@@ -99,10 +108,18 @@ def admin(
     kafka_config[BOOTSTRAP_SERVERS] = bootstrap_servers
 
     kaskade_app = KaskadeAdmin(kafka_config)
+    kaskade_app.theme = theme
     kaskade_app.run()
 
 
 @cli.command(epilog=EPILOG_HELP)
+@cloup.option(
+    "--theme",
+    type=cloup.Choice(available_theme_names(), case_sensitive=False),
+    default=DEFAULT_THEME,
+    show_default=True,
+    help="Textual theme to use.",
+)
 @cloup.option_group(
     "Kafka options",
     cloup.option(
@@ -214,6 +231,7 @@ def consumer(
     value_deserialization: Deserialization,
     from_beginning: bool,
     kafka_config_file: str | None,
+    theme: str,
 ) -> None:
     """
     Consumer mode.
@@ -254,6 +272,7 @@ def consumer(
         key_deserialization,
         value_deserialization,
     )
+    kaskade_app.theme = theme
     kaskade_app.run()
 
 

--- a/kaskade/styles.css
+++ b/kaskade/styles.css
@@ -1,7 +1,3 @@
-$kaskade-green: #00af87;
-$kaskade-orchid: #af5fd7;
-$kaskade-orchid-dark: #5b4666;
-
 Header {
    height: 6;
    layout: horizontal;
@@ -27,42 +23,42 @@ AdminShortcuts {
 }
 
 DataTable {
-    border: solid $kaskade-green 50%;
+    border: solid $secondary 50%;
     height: 100%;
 
-    scrollbar-color: $kaskade-orchid 60%;
-    scrollbar-color-active: $kaskade-orchid;
-    scrollbar-color-hover: $kaskade-orchid 90%;
+    scrollbar-color: $primary 60%;
+    scrollbar-color-active: $primary;
+    scrollbar-color-hover: $primary 90%;
 
-    scrollbar-background: $kaskade-orchid-dark;
-    scrollbar-background-active: $kaskade-orchid-dark;
-    scrollbar-background-hover: $kaskade-orchid-dark;
-    scrollbar-corner-color: $kaskade-orchid-dark;
+    scrollbar-background: $surface-darken-2;
+    scrollbar-background-active: $surface-darken-2;
+    scrollbar-background-hover: $surface-darken-2;
+    scrollbar-corner-color: $surface-darken-2;
 }
 
 DataTable:focus {
-    border: $kaskade-green;
+    border: $secondary;
     background-tint: $surface;
 }
 
 DataTable > .datatable--header {
     text-style: none;
     background-tint: $surface;
-    color: $kaskade-orchid;
+    color: $primary;
 }
 
 DataTable > .datatable--header-hover {
     text-style: none;
     background: $surface;
-    color: $kaskade-orchid;
+    color: $primary;
 }
 
 DataTable > .datatable--hover {
-    background: $kaskade-green 30%;
+    background: $secondary 30%;
 }
 
 DataTable > .datatable--cursor {
-    background: $kaskade-green 70%;
+    background: $secondary 70%;
     color: $text;
 }
 
@@ -72,7 +68,7 @@ DataTable > .datatable--fixed {
 }
 
 DataTable > .datatable--even-row {
-    background: $kaskade-green 5%;
+    background: $secondary 5%;
 }
 
 DeleteTopicScreen {
@@ -93,7 +89,7 @@ FilterTopicsScreen > Input {
 
 .-textual-loading-indicator {
     background: $surface;
-    color: $kaskade-orchid;
+    color: $primary;
 }
 
 CreateTopicScreen {
@@ -101,7 +97,7 @@ CreateTopicScreen {
 }
 
 CreateTopicScreen > Container {
-    border: $kaskade-green;
+    border: $secondary;
     width: 60%;
     height: 21;
     background: $surface;
@@ -110,16 +106,16 @@ CreateTopicScreen > Container {
 
 TopicScreen > ScrollableContainer {
     background: $surface;
-    border: $kaskade-green;
+    border: $secondary;
 
-    scrollbar-color: $kaskade-orchid 60%;
-    scrollbar-color-active: $kaskade-orchid;
-    scrollbar-color-hover: $kaskade-orchid 90%;
+    scrollbar-color: $primary 60%;
+    scrollbar-color-active: $primary;
+    scrollbar-color-hover: $primary 90%;
 
-    scrollbar-background: $kaskade-orchid-dark;
-    scrollbar-background-active: $kaskade-orchid-dark;
-    scrollbar-background-hover: $kaskade-orchid-dark;
-    scrollbar-corner-color: $kaskade-orchid-dark;
+    scrollbar-background: $surface-darken-2;
+    scrollbar-background-active: $surface-darken-2;
+    scrollbar-background-hover: $surface-darken-2;
+    scrollbar-corner-color: $surface-darken-2;
 }
 
 EditTopicScreen {
@@ -127,7 +123,7 @@ EditTopicScreen {
 }
 
 EditTopicScreen > Container {
-    border: $kaskade-green;
+    border: $secondary;
     width: 60%;
     height: 15;
     background: $surface;
@@ -136,23 +132,23 @@ EditTopicScreen > Container {
 
 Input {
     padding: 0 0 0 1;
-    border: solid $kaskade-green 50%;
+    border: solid $secondary 50%;
     background-tint: $surface;
 }
 
 Input:focus {
-    border: $kaskade-green;
+    border: $secondary;
     background: $surface;
 }
 
 RadioSet {
-    border: solid $kaskade-green 50%;
+    border: solid $secondary 50%;
     width: 100%;
     background-tint: $surface;
 }
 
 RadioSet:focus {
-    border: $kaskade-green;
+    border: $secondary;
     background-tint: $surface;
 }
 
@@ -171,7 +167,7 @@ RadioSet > RadioButton.-selected .toggle--button {
 
 RadioSet > RadioButton.-on .toggle--button {
     background-tint: $surface-lighten-3;
-    color: $kaskade-green;
+    color: $secondary;
 }
 
 RadioSet > RadioButton:blur:hover > .toggle--label {
@@ -183,7 +179,7 @@ ChunkSizeScreen {
 }
 
 ChunkSizeScreen > ListView {
-    border: $kaskade-green;
+    border: $secondary;
     width: 60%;
     height: 6;
     background: $surface;
@@ -192,7 +188,7 @@ ChunkSizeScreen > ListView {
 }
 
 ChunkSizeScreen > ListView:focus > ListItem.-highlight > Widget {
-    background: $kaskade-green 70%;
+    background: $secondary 70%;
 }
 
 ChunkSizeScreen > ListView > ListItem  {
@@ -204,7 +200,7 @@ FilterRecordScreen {
 }
 
 FilterRecordScreen > Container {
-    border: $kaskade-green;
+    border: $secondary;
     width: 60%;
     height: 14;
     background: $surface;

--- a/kaskade/styles.css
+++ b/kaskade/styles.css
@@ -1,90 +1,10 @@
-Header {
-   height: 6;
-   layout: horizontal;
-   dock: top;
-   background: $surface;
-}
-
-KaskadeBanner {
-    width: 36;
-    margin: 0 0 0 1;
-}
-
-ConsumerShortcuts {
-    width: 38;
-    dock: right;
-    margin: 1 1 0 0;
-}
-
-AdminShortcuts {
-    width: 40;
-    dock: right;
-    margin: 1 1 0 0;
-}
-
-DataTable {
+DataTable.kaskade-table {
     border: solid $secondary 50%;
     height: 100%;
-
-    scrollbar-color: $primary 60%;
-    scrollbar-color-active: $primary;
-    scrollbar-color-hover: $primary 90%;
-
-    scrollbar-background: $surface-darken-2;
-    scrollbar-background-active: $surface-darken-2;
-    scrollbar-background-hover: $surface-darken-2;
-    scrollbar-corner-color: $surface-darken-2;
 }
 
-DataTable:focus {
+DataTable.kaskade-table:focus {
     border: $secondary;
-    background-tint: $surface;
-}
-
-DataTable > .datatable--header {
-    text-style: none;
-    background-tint: $surface;
-    color: $primary;
-}
-
-DataTable > .datatable--header-hover {
-    text-style: none;
-    background: $surface;
-    color: $primary;
-}
-
-DataTable > .datatable--hover {
-    background: $secondary 30%;
-}
-
-DataTable > .datatable--cursor {
-    background: $secondary 70%;
-    color: $text;
-}
-
-DataTable > .datatable--fixed {
-    background: $surface;
-    color: $text;
-}
-
-DataTable > .datatable--even-row {
-    background: $secondary 5%;
-}
-
-DeleteTopicScreen {
-    align: center middle;
-}
-
-DeleteTopicScreen > Input {
-    width: 60%;
-}
-
-FilterTopicsScreen {
-    align: center middle;
-}
-
-FilterTopicsScreen > Input {
-    width: 60%;
 }
 
 .-textual-loading-indicator {
@@ -92,117 +12,87 @@ FilterTopicsScreen > Input {
     color: $primary;
 }
 
-CreateTopicScreen {
+FilterTopicsScreen,
+DeleteTopicScreen,
+CreateTopicScreen,
+EditTopicScreen,
+FilterRecordScreen,
+ChunkSizeScreen,
+TopicScreen,
+DescribeTopicScreen {
     align: center middle;
 }
 
-CreateTopicScreen > Container {
+FilterTopicsScreen > Input,
+DeleteTopicScreen > Input {
+    width: 72;
+    max-width: 90%;
+}
+
+.topic-form,
+.record-filter {
     border: $secondary;
-    width: 60%;
-    height: 21;
+    width: 72;
+    max-width: 90%;
+    height: auto;
+    max-height: 90%;
     background: $surface;
-    padding: 0 1 0 1;
+    padding: 0 1;
 }
 
-TopicScreen > ScrollableContainer {
-    background: $surface;
-    border: $secondary;
-
-    scrollbar-color: $primary 60%;
-    scrollbar-color-active: $primary;
-    scrollbar-color-hover: $primary 90%;
-
-    scrollbar-background: $surface-darken-2;
-    scrollbar-background-active: $surface-darken-2;
-    scrollbar-background-hover: $surface-darken-2;
-    scrollbar-corner-color: $surface-darken-2;
-}
-
-EditTopicScreen {
-    align: center middle;
-}
-
-EditTopicScreen > Container {
-    border: $secondary;
-    width: 60%;
-    height: 15;
-    background: $surface;
-    padding: 0 1 0 1;
-}
-
-Input {
+Input.kaskade-input {
     padding: 0 0 0 1;
     border: solid $secondary 50%;
-    background-tint: $surface;
 }
 
-Input:focus {
+Input.kaskade-input:focus {
     border: $secondary;
-    background: $surface;
 }
 
-RadioSet {
+RadioSet.kaskade-radio {
     border: solid $secondary 50%;
     width: 100%;
-    background-tint: $surface;
+    height: auto;
 }
 
-RadioSet:focus {
+RadioSet.kaskade-radio:focus {
     border: $secondary;
-    background-tint: $surface;
 }
 
-RadioSet > RadioButton > .toggle--button {
-    background-tint: $surface-lighten-1;
-    color: $surface;
-}
-
-RadioSet > RadioButton.-selected {
-    background-tint: $surface;
-}
-
-RadioSet > RadioButton.-selected .toggle--button {
-    background-tint: $surface-lighten-2;
-}
-
-RadioSet > RadioButton.-on .toggle--button {
-    background-tint: $surface-lighten-3;
-    color: $secondary;
-}
-
-RadioSet > RadioButton:blur:hover > .toggle--label {
-    background: $surface;
-}
-
-ChunkSizeScreen {
-    align: center middle;
-}
-
-ChunkSizeScreen > ListView {
+ChunkSizeScreen > OptionList {
     border: $secondary;
-    width: 60%;
-    height: 6;
+    width: 40;
+    max-width: 90%;
+    height: 8;
     background: $surface;
-    padding: 0 1 0 1;
-    background-tint: $surface;
+    padding: 0 1;
 }
 
-ChunkSizeScreen > ListView:focus > ListItem.-highlight > Widget {
-    background: $secondary 70%;
-}
-
-ChunkSizeScreen > ListView > ListItem  {
-    background: $surface;
-}
-
-FilterRecordScreen {
-    align: center middle;
-}
-
-FilterRecordScreen > Container {
+TopicScreen > .record-details {
     border: $secondary;
-    width: 60%;
-    height: 14;
+    width: 90;
+    max-width: 95%;
+    height: 80%;
     background: $surface;
-    padding: 0 1 0 1;
+}
+
+DescribeTopicScreen > TabbedContent {
+    width: 95%;
+    height: 90%;
+}
+
+DescribeTopicScreen TabbedContent > ContentSwitcher,
+DescribeTopicScreen TabPane {
+    height: 100%;
+    padding: 0;
+}
+
+Screen.-narrow > .topic-form,
+Screen.-narrow > .record-filter,
+Screen.-narrow > Input,
+Screen.-narrow > OptionList,
+Screen.-narrow > .record-details,
+DescribeTopicScreen.-narrow > TabbedContent {
+    width: 100%;
+    max-width: 100%;
 }

--- a/kaskade/themes.py
+++ b/kaskade/themes.py
@@ -64,6 +64,15 @@ class KaskadeApp(App):
             tooltip="Quit Kaskade and return to the command prompt.",
             id="app.quit",
         ),
+        Binding(
+            "ctrl+p",
+            "command_palette",
+            "Palette",
+            show=False,
+            priority=True,
+            tooltip="Search available Kaskade and Textual commands.",
+            id="app.command-palette",
+        ),
     ]
 
     def __init__(self) -> None:

--- a/kaskade/themes.py
+++ b/kaskade/themes.py
@@ -1,0 +1,68 @@
+from rich.theme import Theme as RichTheme
+from textual.app import App
+from textual.theme import BUILTIN_THEMES, Theme, ThemeProvider
+
+DEFAULT_THEME = "eva01"
+
+EVA01_THEME = Theme(
+    name=DEFAULT_THEME,
+    primary="#9B4DCA",
+    secondary="#A6FF4D",
+    warning="#FF9D1C",
+    error="#FF4D5A",
+    success="#A6FF4D",
+    accent="#FF7A00",
+    foreground="#F3ECFF",
+    background="#100A1C",
+    surface="#1C1030",
+    panel="#2A1845",
+    boost="#341B55",
+    dark=True,
+)
+
+
+def available_theme_names() -> tuple[str, ...]:
+    """Return every Textual built-in theme plus Kaskade's default theme."""
+    return tuple(sorted((*BUILTIN_THEMES, EVA01_THEME.name)))
+
+
+def _rich_color(color: str) -> str:
+    """Translate Textual ANSI color tokens into Rich color names."""
+    return color.removeprefix("ansi_")
+
+
+class KaskadeApp(App):
+    """Base application with Textual and Rich theme support."""
+
+    COMMANDS = App.COMMANDS | {ThemeProvider}
+
+    def __init__(self) -> None:
+        self._rich_theme_pushed = False
+        super().__init__()
+        self.register_theme(EVA01_THEME)
+        self.theme = DEFAULT_THEME
+        self._sync_rich_theme()
+
+    def watch_theme(self, _: str) -> None:
+        self._sync_rich_theme()
+
+    def _sync_rich_theme(self) -> None:
+        """Expose the active Textual colors to Rich renderables by semantic name."""
+        if not hasattr(self, "console"):
+            return
+
+        if self._rich_theme_pushed:
+            self.console.pop_theme()
+
+        theme = self.current_theme
+        styles = {
+            "primary": _rich_color(theme.primary),
+            "secondary": _rich_color(theme.secondary or theme.primary),
+            "warning": _rich_color(theme.warning or theme.primary),
+            "error": _rich_color(theme.error or theme.primary),
+            "success": _rich_color(theme.success or theme.primary),
+            "accent": _rich_color(theme.accent or theme.primary),
+            "repr.str": _rich_color(theme.primary),
+        }
+        self.console.push_theme(RichTheme(styles))
+        self._rich_theme_pushed = True

--- a/kaskade/themes.py
+++ b/kaskade/themes.py
@@ -94,7 +94,10 @@ class KaskadeApp(App):
 
     def get_system_commands(self, screen: Screen) -> Iterable[SystemCommand]:
         """Add active Kaskade bindings to Textual's command palette."""
-        yield from super().get_system_commands(screen)
+        widget_size_actions = (screen.action_maximize, screen.action_minimize)
+        for command in super().get_system_commands(screen):
+            if command.callback not in widget_size_actions:
+                yield command
 
         command_ids: set[str] = set()
         for namespace, binding, enabled, _ in screen.active_bindings.values():

--- a/kaskade/themes.py
+++ b/kaskade/themes.py
@@ -6,7 +6,7 @@ from rich.theme import Theme as RichTheme
 from textual.app import App, SystemCommand
 from textual.binding import Binding, BindingType
 from textual.screen import Screen
-from textual.theme import BUILTIN_THEMES, Theme, ThemeProvider
+from textual.theme import BUILTIN_THEMES, Theme
 from textual.widgets import HelpPanel
 
 DEFAULT_THEME = "eva01"
@@ -48,7 +48,6 @@ class KaskadeApp(App):
         (0, "-narrow"),
         (80, "-wide"),
     ]
-    COMMANDS = App.COMMANDS | {ThemeProvider}
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding(
             "f1",

--- a/kaskade/themes.py
+++ b/kaskade/themes.py
@@ -1,8 +1,16 @@
+from collections.abc import Iterable
+from functools import partial
+from typing import ClassVar
+
 from rich.theme import Theme as RichTheme
-from textual.app import App
+from textual.app import App, SystemCommand
+from textual.binding import Binding, BindingType
+from textual.screen import Screen
 from textual.theme import BUILTIN_THEMES, Theme, ThemeProvider
+from textual.widgets import HelpPanel
 
 DEFAULT_THEME = "eva01"
+KASKADE_COMMAND_ID_PREFIX = "kaskade."
 
 EVA01_THEME = Theme(
     name=DEFAULT_THEME,
@@ -34,7 +42,30 @@ def _rich_color(color: str) -> str:
 class KaskadeApp(App):
     """Base application with Textual and Rich theme support."""
 
+    TITLE = "Kaskade"
+    BINDING_GROUP_TITLE = "Application"
+    HORIZONTAL_BREAKPOINTS = [  # noqa: RUF012
+        (0, "-narrow"),
+        (80, "-wide"),
+    ]
     COMMANDS = App.COMMANDS | {ThemeProvider}
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding(
+            "f1",
+            "toggle_help",
+            "Help",
+            tooltip="Show all shortcuts available in the current context.",
+            id="help.toggle",
+        ),
+        Binding(
+            "ctrl+q",
+            "quit",
+            "Quit",
+            priority=True,
+            tooltip="Quit Kaskade and return to the command prompt.",
+            id="app.quit",
+        ),
+    ]
 
     def __init__(self) -> None:
         self._rich_theme_pushed = False
@@ -45,6 +76,34 @@ class KaskadeApp(App):
 
     def watch_theme(self, _: str) -> None:
         self._sync_rich_theme()
+
+    def action_toggle_help(self) -> None:
+        """Show or hide Textual's contextual help panel."""
+        if self.screen.query(HelpPanel):
+            self.action_hide_help_panel()
+        else:
+            self.action_show_help_panel()
+
+    def get_system_commands(self, screen: Screen) -> Iterable[SystemCommand]:
+        """Add active Kaskade bindings to Textual's command palette."""
+        yield from super().get_system_commands(screen)
+
+        command_ids: set[str] = set()
+        for namespace, binding, enabled, _ in screen.active_bindings.values():
+            if (
+                not enabled
+                or binding.id is None
+                or not binding.id.startswith(KASKADE_COMMAND_ID_PREFIX)
+                or binding.id in command_ids
+            ):
+                continue
+
+            command_ids.add(binding.id)
+            yield SystemCommand(
+                binding.description,
+                binding.tooltip or f"Run {binding.description.lower()}.",
+                partial(self.run_action, binding.action, default_namespace=namespace),
+            )
 
     def _sync_rich_theme(self) -> None:
         """Expose the active Textual colors to Rich renderables by semantic name."""

--- a/tests/tests_main.py
+++ b/tests/tests_main.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -158,7 +159,10 @@ class TestConsumerCli(unittest.TestCase):
     def setUp(self):
         self.runner = CliRunner()
         self.command = "consumer"
-        self.temp_descriptor = self.enterContext(tempfile.NamedTemporaryFile())
+        self.temp_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_directory.cleanup)
+        self.temp_descriptor_path = Path(self.temp_directory.name) / "descriptor"
+        self.temp_descriptor_path.touch()
 
     def test_bootstrap_server_required(self):
         result = self.runner.invoke(cli, [self.command])
@@ -595,7 +599,7 @@ class TestConsumerCli(unittest.TestCase):
                 "-t",
                 EXPECTED_TOPIC,
                 "--protobuf",
-                f"descriptor={self.temp_descriptor.name}",
+                f"descriptor={self.temp_descriptor_path}",
                 "--protobuf",
                 "key=MyMessage",
             ],
@@ -669,7 +673,7 @@ class TestConsumerCli(unittest.TestCase):
                 "-t",
                 EXPECTED_TOPIC,
                 "--protobuf",
-                f"descriptor={self.temp_descriptor.name}",
+                f"descriptor={self.temp_descriptor_path}",
                 "-k",
                 "protobuf",
             ],
@@ -688,7 +692,7 @@ class TestConsumerCli(unittest.TestCase):
                 "-t",
                 EXPECTED_TOPIC,
                 "--protobuf",
-                f"descriptor={self.temp_descriptor.name}",
+                f"descriptor={self.temp_descriptor_path}",
                 "-v",
                 "protobuf",
             ],
@@ -760,7 +764,7 @@ class TestConsumerCli(unittest.TestCase):
                 "-t",
                 EXPECTED_TOPIC,
                 "--protobuf",
-                f"descriptor={self.temp_descriptor.name}",
+                f"descriptor={self.temp_descriptor_path}",
             ],
         )
 
@@ -770,7 +774,7 @@ class TestConsumerCli(unittest.TestCase):
     @patch("kaskade.main.KaskadeConsumer")
     def test_pass_protobuf_configs(self, mock_class_kaskade_consumer):
         expected_descriptor_name = "descriptor"
-        expected_descriptor_value = self.temp_descriptor.name
+        expected_descriptor_value = str(self.temp_descriptor_path)
 
         expected_value_name = "value"
         expected_value = "my-value"

--- a/tests/tests_main.py
+++ b/tests/tests_main.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 from kaskade.configs import BOOTSTRAP_SERVERS
 from kaskade.deserializers import Deserialization
 from kaskade.main import cli
+from kaskade.themes import DEFAULT_THEME
 from tests import faker
 
 EXPECTED_TOPIC = "my.topic"
@@ -77,6 +78,30 @@ class TestAdminCli(unittest.TestCase):
             {BOOTSTRAP_SERVERS: EXPECTED_SERVER, "security.protocol": "SASL_SSL"}
         )
         self.assertEqual(0, result.exit_code)
+
+    @patch("kaskade.main.KaskadeAdmin")
+    def test_default_theme(self, mock_class_kaskade_admin):
+        result = self.runner.invoke(cli, [self.command, "-b", EXPECTED_SERVER])
+
+        self.assertEqual(DEFAULT_THEME, mock_class_kaskade_admin.return_value.theme)
+        self.assertEqual(0, result.exit_code)
+
+    @patch("kaskade.main.KaskadeAdmin")
+    def test_pass_theme(self, mock_class_kaskade_admin):
+        result = self.runner.invoke(
+            cli, [self.command, "-b", EXPECTED_SERVER, "--theme", "dracula"]
+        )
+
+        self.assertEqual("dracula", mock_class_kaskade_admin.return_value.theme)
+        self.assertEqual(0, result.exit_code)
+
+    def test_invalid_theme(self):
+        result = self.runner.invoke(
+            cli, [self.command, "-b", EXPECTED_SERVER, "--theme", "invalid"]
+        )
+
+        self.assertGreater(result.exit_code, 0)
+        self.assertIn("Invalid value for '--theme'", result.output)
 
     @patch("kaskade.main.KaskadeAdmin")
     def test_update_kafka_config_with_extra_config(self, mock_class_kaskade_admin):
@@ -383,6 +408,24 @@ class TestConsumerCli(unittest.TestCase):
             Deserialization.BYTES,
             Deserialization.BYTES,
         )
+        self.assertEqual(0, result.exit_code)
+
+    @patch("kaskade.main.KaskadeConsumer")
+    def test_default_theme(self, mock_class_kaskade_consumer):
+        result = self.runner.invoke(
+            cli, [self.command, "-b", EXPECTED_SERVER, "-t", EXPECTED_TOPIC]
+        )
+
+        self.assertEqual(DEFAULT_THEME, mock_class_kaskade_consumer.return_value.theme)
+        self.assertEqual(0, result.exit_code)
+
+    @patch("kaskade.main.KaskadeConsumer")
+    def test_pass_theme(self, mock_class_kaskade_consumer):
+        result = self.runner.invoke(
+            cli, [self.command, "-b", EXPECTED_SERVER, "-t", EXPECTED_TOPIC, "--theme", "dracula"]
+        )
+
+        self.assertEqual("dracula", mock_class_kaskade_consumer.return_value.theme)
         self.assertEqual(0, result.exit_code)
 
     @patch("kaskade.main.KaskadeConsumer")

--- a/tests/tests_themes.py
+++ b/tests/tests_themes.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import AsyncMock, patch
 
-from textual.theme import BUILTIN_THEMES
+from textual.theme import BUILTIN_THEMES, ThemeProvider
 from textual.widgets import DataTable, Footer, HelpPanel, OptionList, TabbedContent, TabPane
 
 from kaskade.admin import (
@@ -19,7 +19,6 @@ from kaskade.themes import (
     DEFAULT_THEME,
     EVA01_THEME,
     KaskadeApp,
-    ThemeProvider,
     available_theme_names,
 )
 
@@ -53,11 +52,11 @@ class TestThemes(unittest.TestCase):
             self.assertEqual("blue", app.console.get_style("primary").color.name)
             self.assertEqual("cyan", app.console.get_style("secondary").color.name)
 
-    def test_enables_the_command_palette_theme_provider(self):
+    def test_uses_textuals_nested_theme_palette(self):
         app = KaskadeApp()
 
         self.assertTrue(app.use_command_palette)
-        self.assertIn(ThemeProvider, app.COMMANDS)
+        self.assertNotIn(ThemeProvider, app.COMMANDS)
 
     def test_custom_bindings_have_descriptions(self):
         binding_owners = (
@@ -139,7 +138,9 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                     labels,
                 )
                 self.assertIn("Topics", table.border_title)
-                self.assertTrue({"Describe", "Filter", "Refresh", "Create"} <= command_titles)
+                self.assertTrue(
+                    {"Theme", "Describe", "Filter", "Refresh", "Create"} <= command_titles
+                )
 
     async def test_topic_details_use_native_tabs_and_a_contextual_footer(self):
         with patch("kaskade.admin.TopicService") as topic_service:
@@ -170,6 +171,10 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 options = app.screen.query_one(OptionList)
                 self.assertEqual(2, options.highlighted)
                 self.assertEqual("100", options.get_option_at_index(2).id)
+                self.assertEqual(
+                    ["25", "50", "100", "500", "1000", "1500"],
+                    [option.id for option in options.options],
+                )
                 self.assertIsInstance(app.screen.query_one(Footer), Footer)
 
     async def test_renders_dark_light_and_ansi_themes(self):

--- a/tests/tests_themes.py
+++ b/tests/tests_themes.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, patch
 
 from textual.theme import BUILTIN_THEMES, ThemeProvider
 from textual.widgets import DataTable, Footer, HelpPanel, OptionList, TabbedContent, TabPane
+from textual.widgets._footer import FooterKey
 
 from kaskade.admin import (
     CreateTopicScreen,
@@ -102,8 +103,12 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 self.assertIsInstance(app.query_one(Footer), Footer)
                 self.assertIs(table, app.screen.focused)
                 self.assertTrue(
-                    {"Describe", "Filter", "Refresh", "Create", "Quit"} <= active_descriptions
+                    {"Describe", "Filter", "Refresh", "Create", "Quit", "Palette"}
+                    <= active_descriptions
                 )
+                palette_keys = [key for key in app.query(FooterKey) if key.key == "ctrl+p"]
+                self.assertEqual(1, len(palette_keys))
+                self.assertEqual("Palette", palette_keys[0].description)
 
                 await pilot.press("f1")
                 self.assertIsInstance(app.screen.query_one(HelpPanel), HelpPanel)

--- a/tests/tests_themes.py
+++ b/tests/tests_themes.py
@@ -146,6 +146,16 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 self.assertTrue(
                     {"Theme", "Describe", "Filter", "Refresh", "Create"} <= command_titles
                 )
+                self.assertTrue({"Maximize", "Minimize"}.isdisjoint(command_titles))
+
+                app.screen.action_maximize()
+                await pilot.pause()
+                maximized_command_titles = {
+                    command.title for command in app.get_system_commands(app.screen)
+                }
+
+                self.assertIs(table, app.screen.maximized)
+                self.assertTrue({"Maximize", "Minimize"}.isdisjoint(maximized_command_titles))
 
     async def test_topic_details_use_native_tabs_and_a_contextual_footer(self):
         with patch("kaskade.admin.TopicService") as topic_service:

--- a/tests/tests_themes.py
+++ b/tests/tests_themes.py
@@ -1,7 +1,20 @@
 import unittest
+from unittest.mock import AsyncMock, patch
 
 from textual.theme import BUILTIN_THEMES
+from textual.widgets import DataTable, Footer, HelpPanel, OptionList, TabbedContent, TabPane
 
+from kaskade.admin import (
+    CreateTopicScreen,
+    DeleteTopicScreen,
+    DescribeTopicScreen,
+    EditTopicScreen,
+    FilterTopicsScreen,
+    KaskadeAdmin,
+    ListTopics,
+)
+from kaskade.consumer import ChunkSizeScreen, FilterRecordScreen, ListRecords, TopicScreen
+from kaskade.models import Topic
 from kaskade.themes import (
     DEFAULT_THEME,
     EVA01_THEME,
@@ -45,3 +58,128 @@ class TestThemes(unittest.TestCase):
 
         self.assertTrue(app.use_command_palette)
         self.assertIn(ThemeProvider, app.COMMANDS)
+
+    def test_custom_bindings_have_descriptions(self):
+        binding_owners = (
+            KaskadeApp,
+            FilterTopicsScreen,
+            DeleteTopicScreen,
+            DescribeTopicScreen,
+            EditTopicScreen,
+            CreateTopicScreen,
+            ListTopics,
+            FilterRecordScreen,
+            ChunkSizeScreen,
+            TopicScreen,
+            ListRecords,
+        )
+
+        for owner in binding_owners:
+            with self.subTest(owner=owner.__name__):
+                for binding in owner.BINDINGS:
+                    self.assertTrue(binding.description)
+                    self.assertTrue(binding.description[0].isupper())
+                    self.assertTrue(binding.tooltip)
+
+    def test_uses_responsive_screen_breakpoints(self):
+        self.assertEqual([(0, "-narrow"), (80, "-wide")], KaskadeApp.HORIZONTAL_BREAKPOINTS)
+
+
+class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
+    async def test_uses_footer_and_toggles_the_native_help_panel(self):
+        with patch("kaskade.admin.TopicService") as topic_service:
+            topic_service.return_value.all = AsyncMock(
+                return_value={"orders": Topic(name="orders")}
+            )
+            app = KaskadeAdmin({})
+
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                table = app.query_one("#topics-table", DataTable)
+                active_descriptions = {
+                    binding.description for _, binding, _, _ in app.screen.active_bindings.values()
+                }
+
+                self.assertIsInstance(app.query_one(Footer), Footer)
+                self.assertIs(table, app.screen.focused)
+                self.assertTrue(
+                    {"Describe", "Filter", "Refresh", "Create", "Quit"} <= active_descriptions
+                )
+
+                await pilot.press("f1")
+                self.assertIsInstance(app.screen.query_one(HelpPanel), HelpPanel)
+
+                await pilot.press("f1")
+                self.assertFalse(app.screen.query(HelpPanel))
+
+    async def test_admin_uses_title_case_labels_and_contextual_palette_commands(self):
+        with patch("kaskade.admin.TopicService") as topic_service:
+            topic_service.return_value.all = AsyncMock(
+                return_value={"orders": Topic(name="orders")}
+            )
+            app = KaskadeAdmin({})
+
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                table = app.query_one("#topics-table", DataTable)
+                labels = [column.label.plain for column in table.columns.values()]
+                command_titles = {command.title for command in app.get_system_commands(app.screen)}
+
+                self.assertEqual(
+                    [
+                        "Name",
+                        "Partitions",
+                        "Replicas",
+                        "In Sync",
+                        "Groups",
+                        "Members",
+                        "Records",
+                        "Lag",
+                    ],
+                    labels,
+                )
+                self.assertIn("Topics", table.border_title)
+                self.assertTrue({"Describe", "Filter", "Refresh", "Create"} <= command_titles)
+
+    async def test_topic_details_use_native_tabs_and_a_contextual_footer(self):
+        with patch("kaskade.admin.TopicService") as topic_service:
+            topic_service.return_value.all = AsyncMock(return_value={})
+            app = KaskadeAdmin({})
+
+            async with app.run_test() as pilot:
+                app.push_screen(DescribeTopicScreen(Topic(name="orders")))
+                await pilot.pause()
+
+                tabs = app.screen.query_one(TabbedContent)
+                partitions = app.screen.query_one("#partitions-table", DataTable)
+                self.assertEqual("partitions", tabs.active)
+                self.assertEqual(3, len(app.screen.query(TabPane)))
+                self.assertEqual(3, len(app.screen.query(DataTable)))
+                self.assertGreater(partitions.content_region.height, 0)
+                self.assertIsInstance(app.screen.query_one(Footer), Footer)
+
+    async def test_chunk_size_uses_an_option_list_with_the_current_value_selected(self):
+        with patch("kaskade.admin.TopicService") as topic_service:
+            topic_service.return_value.all = AsyncMock(return_value={})
+            app = KaskadeAdmin({})
+
+            async with app.run_test() as pilot:
+                app.push_screen(ChunkSizeScreen(100))
+                await pilot.pause()
+
+                options = app.screen.query_one(OptionList)
+                self.assertEqual(2, options.highlighted)
+                self.assertEqual("100", options.get_option_at_index(2).id)
+                self.assertIsInstance(app.screen.query_one(Footer), Footer)
+
+    async def test_renders_dark_light_and_ansi_themes(self):
+        for theme in (DEFAULT_THEME, "textual-light", "ansi-light"):
+            with self.subTest(theme=theme), patch("kaskade.admin.TopicService") as topic_service:
+                topic_service.return_value.all = AsyncMock(return_value={})
+                app = KaskadeAdmin({})
+                app.theme = theme
+
+                async with app.run_test(size=(80, 24)):
+                    screenshot = app.export_screenshot()
+
+                self.assertIn("<svg", screenshot)

--- a/tests/tests_themes.py
+++ b/tests/tests_themes.py
@@ -1,0 +1,47 @@
+import unittest
+
+from textual.theme import BUILTIN_THEMES
+
+from kaskade.themes import (
+    DEFAULT_THEME,
+    EVA01_THEME,
+    KaskadeApp,
+    ThemeProvider,
+    available_theme_names,
+)
+
+
+class TestThemes(unittest.TestCase):
+    def test_registers_textual_themes_and_eva01_by_default(self):
+        app = KaskadeApp()
+
+        self.assertEqual(DEFAULT_THEME, app.theme)
+        self.assertEqual(set(BUILTIN_THEMES) | {DEFAULT_THEME}, set(available_theme_names()))
+        self.assertIn(DEFAULT_THEME, app.available_themes)
+
+    def test_updates_rich_semantic_styles_when_theme_changes(self):
+        app = KaskadeApp()
+
+        self.assertEqual(
+            EVA01_THEME.primary.lower(), app.console.get_style("primary").color.get_truecolor().hex
+        )
+
+        app.theme = "dracula"
+
+        self.assertEqual("#bd93f9", app.console.get_style("primary").color.get_truecolor().hex)
+        self.assertEqual("#6272a4", app.console.get_style("secondary").color.get_truecolor().hex)
+
+    def test_updates_rich_semantic_styles_for_ansi_themes(self):
+        app = KaskadeApp()
+
+        for theme in ("ansi-dark", "ansi-light"):
+            app.theme = theme
+
+            self.assertEqual("blue", app.console.get_style("primary").color.name)
+            self.assertEqual("cyan", app.console.get_style("secondary").color.name)
+
+    def test_enables_the_command_palette_theme_provider(self):
+        app = KaskadeApp()
+
+        self.assertTrue(app.use_command_palette)
+        self.assertIn(ThemeProvider, app.COMMANDS)


### PR DESCRIPTION
## Summary

- add Eva-01 as Kaskade's default theme and expose all bundled Textual themes through the CLI
- use Textual's Theme command for nested runtime theme selection and synchronize Rich semantic styles
- fix ANSI theme color translation
- replace the custom shortcut header with contextual Footers, F1 Help, and searchable Kaskade commands
- adopt native tabs and option lists, responsive theme-aware styling, and consistent Title Case labels
- add 1000 and 1500 record chunk sizes

## Testing

- repository static analysis: mypy, Black, Ruff, and typos
- 77 unit tests
- pre-commit end-to-end tests
- visual smoke checks for Eva-01, Textual Light, ANSI Light, and narrow terminals

Closes #52