### PR TITLE
feat(table): add stretchy data tables

### DIFF
--- a/kaskade/admin.py
+++ b/kaskade/admin.py
@@ -31,6 +31,7 @@ from kaskade.services import (
 from kaskade.themes import KaskadeApp
 from kaskade.unicodes import APPROXIMATION
 from kaskade.utils import make_it_async, notify_error
+from kaskade.widgets import StretchyDataTable
 
 REFRESH_TABLE_DELAY = 1
 FILTER_TOPICS_SHORTCUT = "ctrl+f"
@@ -142,20 +143,22 @@ class DescribeTopicScreen(ModalScreen):
                 yield self._group_members_table()
         yield Footer(compact=True)
 
-    def _new_table(self, table_id: str, count: int, item_name: str) -> DataTable:
-        table: DataTable = DataTable(id=table_id, classes="kaskade-table details-table")
+    def _new_table(self, table_id: str, count: int, item_name: str) -> StretchyDataTable[str]:
+        table: StretchyDataTable[str] = StretchyDataTable(
+            id=table_id, classes="kaskade-table details-table"
+        )
         table.cursor_type = "row"
         table.zebra_stripes = True
         table.border_title = rf"[{PRIMARY}]{self.topic}[/] \[[{PRIMARY}]{count} {item_name}[/]]"
         return table
 
-    def _partitions_table(self) -> DataTable:
+    def _partitions_table(self) -> StretchyDataTable[str]:
         table = self._new_table("partitions-table", self.topic.partitions_count(), "Partitions")
-        table.add_column("ID")
-        table.add_column("Leader")
-        table.add_column("ISRs")
-        table.add_column("Replicas")
-        table.add_column("Records")
+        table.add_column("ID", stretch=1)
+        table.add_column("Leader", stretch=1)
+        table.add_column("ISRs", stretch=1)
+        table.add_column("Replicas", stretch=1)
+        table.add_column("Records", stretch=1)
 
         for partition in self.topic.partitions:
             table.add_row(
@@ -167,15 +170,15 @@ class DescribeTopicScreen(ModalScreen):
             )
         return table
 
-    def _groups_table(self) -> DataTable:
+    def _groups_table(self) -> StretchyDataTable[str]:
         table = self._new_table("groups-table", self.topic.groups_count(), "Groups")
-        table.add_column("ID")
-        table.add_column("Coordinator")
-        table.add_column("State")
-        table.add_column("Assignor")
-        table.add_column("Partitions")
-        table.add_column("Members")
-        table.add_column("Lag")
+        table.add_column("ID", stretch=1)
+        table.add_column("Coordinator", stretch=1)
+        table.add_column("State", stretch=1)
+        table.add_column("Assignor", stretch=1)
+        table.add_column("Partitions", stretch=1)
+        table.add_column("Members", stretch=1)
+        table.add_column("Lag", stretch=1)
 
         for group in self.topic.groups:
             table.add_row(
@@ -189,15 +192,15 @@ class DescribeTopicScreen(ModalScreen):
             )
         return table
 
-    def _group_members_table(self) -> DataTable:
+    def _group_members_table(self) -> StretchyDataTable[str]:
         table = self._new_table(
             "group-members-table", self.topic.group_members_count(), "Group Members"
         )
-        table.add_column("Group")
-        table.add_column("Client ID")
-        table.add_column("Member ID")
-        table.add_column("Host")
-        table.add_column("Assignment")
+        table.add_column("Group", stretch=1)
+        table.add_column("Client ID", stretch=1)
+        table.add_column("Member ID", stretch=1)
+        table.add_column("Host", stretch=1)
+        table.add_column("Assignment", stretch=1)
 
         for group in self.topic.groups:
             for member in group.members:
@@ -484,20 +487,22 @@ class ListTopics(Container):
         self.current_filter: str | None = None
 
     def compose(self) -> ComposeResult:
-        table: DataTable = DataTable(id="topics-table", classes="kaskade-table main-table")
+        table: StretchyDataTable[str] = StretchyDataTable(
+            id="topics-table", classes="kaskade-table main-table"
+        )
         table.cursor_type = "row"
         table.border_title = rf"[{PRIMARY}]Topics[/] \[[{PRIMARY}]0[/]]"
         table.border_subtitle = rf"\[[{PRIMARY}]Admin Mode[/]]"
         table.zebra_stripes = True
 
-        table.add_column("Name")
-        table.add_column("Partitions", width=10)
-        table.add_column("Replicas", width=10)
-        table.add_column("In Sync", width=10)
-        table.add_column("Groups", width=10)
-        table.add_column("Members", width=10)
-        table.add_column("Records", width=10)
-        table.add_column("Lag", width=10)
+        table.add_column("Name", stretch=1)
+        table.add_column("Partitions")
+        table.add_column("Replicas")
+        table.add_column("In Sync")
+        table.add_column("Groups")
+        table.add_column("Members")
+        table.add_column("Records")
+        table.add_column("Lag")
 
         yield table
 

--- a/kaskade/consumer.py
+++ b/kaskade/consumer.py
@@ -19,6 +19,7 @@ from kaskade.models import Record
 from kaskade.services import ConsumerService
 from kaskade.themes import KaskadeApp
 from kaskade.utils import notify_error
+from kaskade.widgets import StretchyDataTable
 
 CHUNKS_SHORTCUT = "#"
 NEXT_SHORTCUT = "n"
@@ -271,14 +272,16 @@ class ListRecords(Container):
         return rf"[{PRIMARY}]Records[/] \[[{PRIMARY}]{self.topic}[/]]{title_filter}\[[{PRIMARY}]{len(self.records)}[/]]"
 
     def compose(self) -> ComposeResult:
-        table: DataTable = DataTable(id="records-table", classes="kaskade-table main-table")
+        table: StretchyDataTable[str] = StretchyDataTable(
+            id="records-table", classes="kaskade-table main-table"
+        )
         table.cursor_type = "row"
         table.border_subtitle = rf"\[[{PRIMARY}]Consumer Mode[/]]"
         table.zebra_stripes = True
         table.border_title = self._get_title()
 
-        table.add_column("Key", width=30)
-        table.add_column("Value", width=45)
+        table.add_column("Key", stretch=2)
+        table.add_column("Value", stretch=3)
         table.add_column("Timestamp", width=23)
         table.add_column("Partition", width=9)
         table.add_column("Offset", width=9)

--- a/kaskade/widgets.py
+++ b/kaskade/widgets.py
@@ -1,0 +1,83 @@
+from typing import Any
+
+from rich.text import TextType
+from textual import events
+from textual.geometry import Size
+from textual.widgets import DataTable
+from textual.widgets.data_table import CellType, ColumnKey
+
+
+class StretchyDataTable(DataTable[CellType]):
+    """A data table whose columns can expand to fill the available width."""
+
+    DEFAULT_CSS = """
+    StretchyDataTable {
+        scrollbar-gutter: stable;
+    }
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._column_minimums: dict[ColumnKey, int] = {}
+        self._column_stretches: dict[ColumnKey, int] = {}
+
+    def add_column(
+        self,
+        label: TextType,
+        *,
+        width: int | None = None,
+        key: str | None = None,
+        default: CellType | None = None,
+        stretch: int = 0,
+    ) -> ColumnKey:
+        """Add a column, optionally assigning it a proportional stretch factor.
+
+        The configured width is the column's minimum width. If omitted, the
+        rendered label width is used as the minimum. Remaining table space is
+        divided between columns according to their stretch factors.
+        """
+        if stretch < 0:
+            raise ValueError("stretch must be greater than or equal to zero")
+
+        column_key = super().add_column(label, width=width, key=key, default=default)
+        column = self.columns[column_key]
+        column.auto_width = False
+        self._column_minimums[column_key] = column.width
+        self._column_stretches[column_key] = stretch
+
+        if self.is_mounted:
+            self.call_after_refresh(self._stretch_columns)
+
+        return column_key
+
+    def on_resize(self, _event: events.Resize) -> None:
+        self._stretch_columns()
+
+    def _stretch_columns(self) -> None:
+        columns = self.ordered_columns
+        if not columns:
+            return
+
+        row_label_width = self._row_label_column_width
+        available_width = max(0, self.scrollable_content_region.width - row_label_width)
+        padding_width = 2 * self.cell_padding * len(columns)
+        available_content_width = max(0, available_width - padding_width)
+
+        minimums = [self._column_minimums[column.key] for column in columns]
+        stretches = [self._column_stretches[column.key] for column in columns]
+        extra_width = max(0, available_content_width - sum(minimums))
+        total_stretch = sum(stretches)
+
+        allocated_width = 0
+        cumulative_stretch = 0
+        for column, minimum, stretch in zip(columns, minimums, stretches):
+            cumulative_stretch += stretch
+            stretched_width = (
+                extra_width * cumulative_stretch // total_stretch if total_stretch else 0
+            )
+            column.width = minimum + stretched_width - allocated_width
+            allocated_width = stretched_width
+
+        data_width = sum(column.get_render_width(self) for column in columns)
+        self.virtual_size = Size(data_width + row_label_width, self.virtual_size.height)
+        self.refresh()

--- a/tests/tests_themes.py
+++ b/tests/tests_themes.py
@@ -14,7 +14,14 @@ from kaskade.admin import (
     KaskadeAdmin,
     ListTopics,
 )
-from kaskade.consumer import ChunkSizeScreen, FilterRecordScreen, ListRecords, TopicScreen
+from kaskade.consumer import (
+    ChunkSizeScreen,
+    FilterRecordScreen,
+    KaskadeConsumer,
+    ListRecords,
+    TopicScreen,
+)
+from kaskade.deserializers import Deserialization
 from kaskade.models import Topic
 from kaskade.themes import (
     DEFAULT_THEME,
@@ -22,6 +29,7 @@ from kaskade.themes import (
     KaskadeApp,
     available_theme_names,
 )
+from kaskade.widgets import StretchyDataTable
 
 
 class TestThemes(unittest.TestCase):
@@ -142,6 +150,8 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                     ],
                     labels,
                 )
+                self.assertIsInstance(table, StretchyDataTable)
+                self.assertFalse(table.show_horizontal_scrollbar)
                 self.assertIn("Topics", table.border_title)
                 self.assertTrue(
                     {"Theme", "Describe", "Filter", "Refresh", "Create"} <= command_titles
@@ -157,6 +167,34 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 self.assertIs(table, app.screen.maximized)
                 self.assertTrue({"Maximize", "Minimize"}.isdisjoint(maximized_command_titles))
 
+    async def test_consumer_uses_a_stretchy_records_table(self):
+        with patch("kaskade.consumer.ConsumerService") as consumer_service:
+            consumer_service.return_value.consume = AsyncMock(return_value=[])
+            app = KaskadeConsumer(
+                "orders",
+                {},
+                {},
+                {},
+                {},
+                Deserialization.STRING,
+                Deserialization.STRING,
+            )
+
+            async with app.run_test(size=(80, 24)) as pilot:
+                await pilot.pause()
+                table = app.query_one("#records-table", DataTable)
+
+                self.assertIsInstance(table, StretchyDataTable)
+                self.assertEqual(
+                    ["Key", "Value", "Timestamp", "Partition", "Offset", "Headers"],
+                    [column.label.plain for column in table.ordered_columns],
+                )
+                self.assertEqual(
+                    [23, 9, 9, 9],
+                    [column.width for column in table.ordered_columns[2:]],
+                )
+                self.assertFalse(table.show_horizontal_scrollbar)
+
     async def test_topic_details_use_native_tabs_and_a_contextual_footer(self):
         with patch("kaskade.admin.TopicService") as topic_service:
             topic_service.return_value.all = AsyncMock(return_value={})
@@ -168,10 +206,13 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
 
                 tabs = app.screen.query_one(TabbedContent)
                 partitions = app.screen.query_one("#partitions-table", DataTable)
+                detail_tables = list(app.screen.query(StretchyDataTable))
                 self.assertEqual("partitions", tabs.active)
                 self.assertEqual(3, len(app.screen.query(TabPane)))
                 self.assertEqual(3, len(app.screen.query(DataTable)))
+                self.assertEqual(3, len(detail_tables))
                 self.assertGreater(partitions.content_region.height, 0)
+                self.assertFalse(partitions.show_horizontal_scrollbar)
                 self.assertIsInstance(app.screen.query_one(Footer), Footer)
 
     async def test_chunk_size_uses_an_option_list_with_the_current_value_selected(self):

--- a/tests/tests_widgets.py
+++ b/tests/tests_widgets.py
@@ -1,0 +1,74 @@
+import unittest
+
+from textual.app import App, ComposeResult
+
+from kaskade.widgets import StretchyDataTable
+
+
+class StretchyTableApp(App):
+    CSS = "StretchyDataTable { border: solid red; height: 100%; }"
+
+    def __init__(self, *, rows: int = 0, wide_columns: bool = False) -> None:
+        super().__init__()
+        self.rows = rows
+        self.wide_columns = wide_columns
+
+    def compose(self) -> ComposeResult:
+        table = StretchyDataTable[str]()
+        minimum = 10 if self.wide_columns else 4
+        table.add_column("First", width=minimum, stretch=1)
+        table.add_column("Second", width=minimum, stretch=2)
+        table.add_column("Fixed", width=minimum)
+        for row in range(self.rows):
+            table.add_row(str(row), str(row), str(row))
+        yield table
+
+
+class TestStretchyDataTable(unittest.IsolatedAsyncioTestCase):
+    async def test_fills_available_width_and_resizes_proportionally(self):
+        app = StretchyTableApp(rows=100)
+
+        async with app.run_test(size=(80, 24)) as pilot:
+            table = app.query_one(StretchyDataTable)
+            await pilot.pause()
+
+            initial_widths = [column.width for column in table.ordered_columns]
+            rendered_width = sum(column.get_render_width(table) for column in table.ordered_columns)
+            self.assertEqual(table.scrollable_content_region.width, rendered_width)
+            self.assertTrue(table.show_vertical_scrollbar)
+            self.assertFalse(table.show_horizontal_scrollbar)
+            self.assertEqual(4, initial_widths[2])
+            self.assertAlmostEqual(
+                2,
+                (initial_widths[1] - 4) / (initial_widths[0] - 4),
+                delta=0.1,
+            )
+
+            await pilot.resize_terminal(120, 30)
+            resized_widths = [column.width for column in table.ordered_columns]
+            rendered_width = sum(column.get_render_width(table) for column in table.ordered_columns)
+            self.assertEqual(table.scrollable_content_region.width, rendered_width)
+            self.assertGreater(resized_widths[0], initial_widths[0])
+            self.assertGreater(resized_widths[1], initial_widths[1])
+            self.assertEqual(initial_widths[2], resized_widths[2])
+            self.assertFalse(table.show_horizontal_scrollbar)
+
+    async def test_preserves_minimum_widths_when_the_table_is_too_narrow(self):
+        app = StretchyTableApp(wide_columns=True)
+
+        async with app.run_test(size=(20, 10)) as pilot:
+            table = app.query_one(StretchyDataTable)
+            await pilot.pause()
+
+            self.assertEqual([10, 10, 10], [column.width for column in table.ordered_columns])
+            self.assertTrue(table.show_horizontal_scrollbar)
+
+    async def test_accepts_resize_events_before_columns_are_added(self):
+        class EmptyTableApp(App):
+            def compose(self) -> ComposeResult:
+                yield StretchyDataTable()
+
+        app = EmptyTableApp()
+
+        async with app.run_test(size=(40, 10)):
+            self.assertEqual([], app.query_one(StretchyDataTable).ordered_columns)


### PR DESCRIPTION
feat(table): add stretchy data tables

Add responsive, weighted table columns across the application and preserve minimum widths for narrow terminals.

Closes #55

Assisted-by: Codex GPT-5