### PR TITLE
perf: improve admin refresh and consumer loading

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -48,7 +48,8 @@ warnings in the application.
   automatic, manual, resumed, or post-mutation refresh work.
 - Admin auto-refresh defaults to 30 seconds, pauses while another screen is
   open, and is configured with `admin.refresh_interval_seconds` in Kaskade's
-  YAML configuration. A value of `0` disables it.
+  YAML configuration or overridden per session with `admin --refresh-interval`.
+  A value of `0` disables it.
 
 ## TUI Interaction Conventions
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -38,6 +38,18 @@ Missing, empty, malformed, or partially invalid Kaskade configuration must not
 make startup fragile. Ignore invalid entries, retain valid entries, and surface
 warnings in the application.
 
+## Admin Data Loading
+
+- Render topic metadata before loading record and consumer-group metrics.
+- Fetch partition offsets with batched Admin API requests and consumer-group
+  offsets with bounded concurrency; do not create temporary consumers for admin
+  metrics.
+- Keep the last complete metrics visible during refreshes and never overlap
+  automatic, manual, resumed, or post-mutation refresh work.
+- Admin auto-refresh defaults to 30 seconds, pauses while another screen is
+  open, and is configured with `admin.refresh_interval_seconds` in Kaskade's
+  YAML configuration. A value of `0` disables it.
+
 ## TUI Interaction Conventions
 
 Kaskade follows familiar k9s/Vim-style terminal interactions where practical:

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,5 +1,11 @@
 # Agent Instructions
 
+## Code Quality
+
+- Keep cyclomatic complexity at or below 10. The repository-wide Ruff `C901`
+  check is part of `scripts.analyze`; prefer focused named helpers over lint
+  suppressions.
+
 ## Living Knowledge and Documentation
 
 - Treat this file as the project's living operational knowledge. Update it when
@@ -46,6 +52,9 @@ warnings in the application.
   metrics.
 - Keep the last complete metrics visible during refreshes and never overlap
   automatic, manual, resumed, or post-mutation refresh work.
+- Coalesce non-periodic refresh requests behind active work and keep refresh
+  state transitions in the shared coordinator rather than adding independent
+  flags to the topic list.
 - Admin auto-refresh defaults to 30 seconds, pauses while another screen is
   open, and is configured with `admin.refresh_interval_seconds` in Kaskade's
   YAML configuration or overridden per session with `admin --refresh-interval`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add configurable admin auto-refresh with modal-aware pause and resume behavior
+- Add configurable admin auto-refresh, including a command-line override, with modal-aware pause and resume behavior
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add configurable admin auto-refresh with modal-aware pause and resume behavior
+
+### Changed
+
+- Load admin topic metrics progressively with batched Kafka Admin requests
+- Consume records in batches and reuse deserialized record values
+
 ## [4.0.7] - 2026-03-02
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Load admin topic metrics progressively with batched Kafka Admin requests
 - Consume records in batches and reuse deserialized record values
+- Simplify refresh, settings, Kafka mapping, and deserialization control flow
+- Coalesce manual refresh requests to prevent overlapping broker scans
 
 ## [4.0.7] - 2026-03-02
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ It includes features like:
 Kaskade does not include:
 
 - Schema Registry for protobuf.
-- Runtime auto-refresh.
 
 ## Screenshots
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -41,6 +41,15 @@ admin:
 
 Use `0` to disable auto-refresh. Enabled intervals must be at least 5 seconds. Missing or invalid values use the 30-second default and invalid values produce an in-app warning.
 
+Override the configured interval for one admin session with `--refresh-interval`:
+
+```bash
+kaskade admin -b my-kafka:9092 --refresh-interval 10
+kaskade admin -b my-kafka:9092 --refresh-interval 0
+```
+
+The command-line value takes precedence over `config.yaml`. As with the YAML setting, `0` disables auto-refresh and enabled intervals must be at least 5 seconds.
+
 ### Keyboard shortcuts
 
 Kaskade supports arrow keys and Vim-style navigation. The defaults follow familiar k9s conventions where the applications have equivalent actions.

--- a/USAGE.md
+++ b/USAGE.md
@@ -28,6 +28,19 @@ kaskade admin -b my-kafka:9092 --theme dracula
 
 While Kaskade is running, press `:` (or `Ctrl+P`) and select a theme from the Commands window. Theme changes apply only to the current session.
 
+### Admin auto-refresh
+
+Admin mode refreshes topic metadata and metrics every 30 seconds. Auto-refresh pauses while a dialog, topic details, Help, or the command palette is open, then refreshes after returning to the topic list. Press `Ctrl+R` to refresh immediately.
+
+Configure the interval in Kaskade's `config.yaml`:
+
+```yaml
+admin:
+  refresh_interval_seconds: 30
+```
+
+Use `0` to disable auto-refresh. Enabled intervals must be at least 5 seconds. Missing or invalid values use the 30-second default and invalid values produce an in-app warning.
+
 ### Keyboard shortcuts
 
 Kaskade supports arrow keys and Vim-style navigation. The defaults follow familiar k9s conventions where the applications have equivalent actions.
@@ -152,7 +165,7 @@ sasl.password=replace-with-your-api-secret
 client.id=kaskade
 ```
 
-This file contains only properties for `confluent-kafka`; Kaskade UI and keymap settings remain in `config.yaml` as documented above. The required `-b/--bootstrap-servers` option sets `bootstrap.servers`, so it does not need to appear in `kafka.properties`.
+This file contains only properties for `confluent-kafka`; Kaskade UI, admin, and keymap settings remain in `config.yaml` as documented above. The required `-b/--bootstrap-servers` option sets `bootstrap.servers`, so it does not need to appear in `kafka.properties`.
 
 Configuration precedence, from lowest to highest, is:
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,4 +1,8 @@
 # Copy this file to ~/.config/kaskade/config.yaml on Linux or macOS.
+# Set to 0 to disable auto-refresh. Enabled intervals must be at least 5 seconds.
+admin:
+  refresh_interval_seconds: 30
+
 # Values are Textual key names; use commas to assign multiple keys.
 keymap:
   # Application

--- a/kaskade/admin.py
+++ b/kaskade/admin.py
@@ -1,3 +1,6 @@
+import asyncio
+from datetime import datetime
+from time import perf_counter
 from typing import Any, ClassVar
 
 from confluent_kafka import KafkaException
@@ -19,6 +22,7 @@ from textual.widgets import (
     Tabs,
 )
 
+from kaskade import logger
 from kaskade.colors import PRIMARY
 from kaskade.configs import (
     CLEANUP_POLICY_CONFIG,
@@ -27,8 +31,9 @@ from kaskade.configs import (
     RETENTION_MS_CONFIG,
 )
 from kaskade.help import HelpableModalScreen, modal_bindings
-from kaskade.models import CleanupPolicy, Topic
+from kaskade.models import CleanupPolicy, MetricState, Topic
 from kaskade.services import (
+    ADMIN_EXCEPTIONS,
     TopicService,
 )
 from kaskade.themes import KaskadeApp
@@ -46,6 +51,8 @@ NEW_TOPIC_SHORTCUT = "n,ctrl+n"
 DELETE_TOPIC_SHORTCUT = "ctrl+d"
 EDIT_TOPIC_SHORTCUT = "e,ctrl+e"
 REFRESH_TOPICS_SHORTCUT = "ctrl+r"
+LOADING_METRIC = "…"
+UNAVAILABLE_METRIC = "—"
 
 
 def _valid_topic_name(name: str) -> bool:
@@ -586,6 +593,11 @@ class ListTopics(Container):
         self.topics: dict[str, Topic] = {}
         self.current_topic: Topic | None = None
         self.current_filter: str | None = None
+        self.last_updated_at: datetime | None = None
+        self._refresh_generation = 0
+        self._refreshing = False
+        self._refresh_pending = False
+        self._mutation_in_progress = False
 
     def compose(self) -> ComposeResult:
         table: StretchyDataTable[str] = StretchyDataTable(
@@ -596,20 +608,22 @@ class ListTopics(Container):
         table.border_subtitle = rf"\[[{PRIMARY}]Admin Mode[/]]"
         table.zebra_stripes = True
 
-        table.add_column("Name", stretch=1)
-        table.add_column("Partitions")
-        table.add_column("Replicas")
-        table.add_column("In Sync")
-        table.add_column("Groups")
-        table.add_column("Members")
-        table.add_column("Records")
-        table.add_column("Lag")
+        table.add_column("Name", key="name", stretch=1)
+        table.add_column("Partitions", key="partitions")
+        table.add_column("Replicas", key="replicas")
+        table.add_column("In Sync", key="isrs")
+        table.add_column("Groups", key="groups")
+        table.add_column("Members", key="members")
+        table.add_column("Records", key="records")
+        table.add_column("Lag", key="lag")
 
         yield table
 
     def on_mount(self) -> None:
-        self.query_one("#topics-table", DataTable).focus()
-        self.action_refresh()
+        table = self.query_one("#topics-table", DataTable)
+        table.focus()
+        table.loading = True
+        self._update_status(refreshing=True)
 
     def on_data_table_row_highlighted(self, data: DataTable.RowHighlighted) -> None:
         if data.row_key.value is None:
@@ -617,23 +631,125 @@ class ListTopics(Container):
         self.current_topic = self.topics.get(data.row_key.value)
         self.refresh_bindings()
 
-    async def refresh_table(self) -> None:
-        try:
-            self.topics = await self.topic_service.all()
-        except KafkaException as ex:
-            notify_error(self.app, "Kafka Error", ex)
+    def action_refresh(self) -> None:
+        self.request_refresh("manual")
 
-        self.fill_table()
+    def request_refresh(self, reason: str) -> None:
+        if self._mutation_in_progress:
+            if reason != "periodic":
+                self._refresh_pending = True
+            return
+        if self._refreshing:
+            if reason == "manual":
+                self._start_refresh()
+            elif reason != "periodic":
+                self._refresh_pending = True
+            return
+        self._start_refresh()
+
+    def _start_refresh(self) -> None:
+        self._refresh_generation += 1
+        generation = self._refresh_generation
+        self._refreshing = True
+        self._update_status(refreshing=True)
+        self.refresh_topics(generation)
 
     @work(exclusive=True, group="topics-refresh")
-    async def action_refresh(self) -> None:
-        self.start_loading_table()
-        await self.refresh_table()
+    async def refresh_topics(self, generation: int) -> None:
+        table = self.query_one(DataTable)
+        if not self.topics:
+            table.loading = True
+        started_at = perf_counter()
+        offsets_task: asyncio.Task[Any] | None = None
+        groups_task: asyncio.Task[Any] | None = None
+
+        try:
+            refreshed_topics = await self.topic_service.metadata()
+            self._preserve_completed_metrics(refreshed_topics)
+            if generation != self._refresh_generation:
+                return
+
+            self.topics = refreshed_topics
+            self.fill_table()
+            table.loading = False
+
+            offsets_task = asyncio.create_task(self.topic_service.enrich_offsets(self.topics))
+            groups_task = asyncio.create_task(self.topic_service.load_groups())
+
+            offsets_result = await offsets_task
+            if generation != self._refresh_generation:
+                return
+            self.fill_table()
+            if offsets_result.errors:
+                self._notify_stage_failure("record metrics", len(offsets_result.errors))
+
+            groups_snapshot = await groups_task
+            if generation != self._refresh_generation:
+                return
+            groups_result = self.topic_service.apply_groups(self.topics, groups_snapshot)
+            self.fill_table()
+            if groups_result.errors:
+                self._notify_stage_failure("consumer-group metrics", len(groups_result.errors))
+
+            self.last_updated_at = datetime.now().astimezone()
+            logger.info(
+                "admin refresh completed topics=%d elapsed=%.3fs",
+                len(self.topics),
+                perf_counter() - started_at,
+            )
+        except KafkaException as ex:
+            notify_error(self.app, "Kafka Error", ex)
+        except ADMIN_EXCEPTIONS as ex:
+            notify_error(self.app, "Refresh Error", ex)
+        finally:
+            for task in (offsets_task, groups_task):
+                if task is not None and not task.done():
+                    task.cancel()
+            if generation == self._refresh_generation:
+                table.loading = False
+                self._refreshing = False
+                self._update_status(refreshing=False)
+                refresh_completed = getattr(self.app, "admin_refresh_completed", None)
+                if refresh_completed is not None:
+                    refresh_completed()
+                if self._refresh_pending and not self._mutation_in_progress:
+                    self._refresh_pending = False
+                    self.call_after_refresh(lambda: self.request_refresh("pending"))
+
+    def _preserve_completed_metrics(self, refreshed_topics: dict[str, Topic]) -> None:
+        for topic_name, refreshed_topic in refreshed_topics.items():
+            previous_topic = self.topics.get(topic_name)
+            if previous_topic is None:
+                continue
+            previous_partitions = {
+                partition.id: partition for partition in previous_topic.partitions
+            }
+            if set(previous_partitions) != {
+                partition.id for partition in refreshed_topic.partitions
+            }:
+                continue
+            if previous_topic.records_state is MetricState.READY:
+                for partition in refreshed_topic.partitions:
+                    previous_partition = previous_partitions[partition.id]
+                    partition.low = previous_partition.low
+                    partition.high = previous_partition.high
+                refreshed_topic.records_state = MetricState.READY
+            if previous_topic.groups_state is MetricState.READY:
+                refreshed_topic.groups = previous_topic.groups
+                refreshed_topic.groups_state = MetricState.READY
+
+    def _notify_stage_failure(self, stage: str, error_count: int) -> None:
+        self.app.notify(
+            f"Could not refresh {stage} ({error_count} failed request(s)).",
+            title="Partial Refresh",
+            severity="warning",
+        )
 
     def action_new(self) -> None:
         def on_dismiss(result: NewTopic | None) -> None:
             if result is None:
                 return
+            self._mutation_in_progress = True
             self.create_topic(result)
 
         self.app.push_screen(CreateTopicScreen(), on_dismiss)
@@ -642,6 +758,7 @@ class ListTopics(Container):
     async def create_topic(self, topic: NewTopic) -> None:
         """Create a topic without blocking Textual's message loop."""
         self.start_loading_table()
+        refresh_after = False
         try:
             await make_it_async(self.topic_service.create, [topic])
             self.app.notify(
@@ -649,11 +766,12 @@ class ListTopics(Container):
                 title="Topic Created",
                 severity="information",
             )
-            self.set_timer(REFRESH_TABLE_DELAY, self.action_refresh)
+            refresh_after = True
         except KafkaException as ex:
             notify_error(self.app, "Kafka Error", ex)
         finally:
             self.finish_loading_table()
+            self._finish_mutation(refresh_after)
 
     def start_loading_table(self) -> None:
         table = self.query_one(DataTable)
@@ -693,6 +811,7 @@ class ListTopics(Container):
         def on_dismiss(result: bool | None) -> None:
             if not result:
                 return
+            self._mutation_in_progress = True
             self.update_topic(topic, edit_topic_screen)
 
         self.app.push_screen(edit_topic_screen, on_dismiss)
@@ -701,6 +820,7 @@ class ListTopics(Container):
     async def update_topic(self, topic: Topic, editor: EditTopicScreen) -> None:
         """Update a topic without blocking Textual's message loop."""
         self.start_loading_table()
+        refresh_after = False
         try:
             partition_count = int(editor.partitions)
             if partition_count > topic.partitions_count():
@@ -720,10 +840,12 @@ class ListTopics(Container):
                 title="Topic Updated",
                 severity="information",
             )
-            self.set_timer(REFRESH_TABLE_DELAY, self.refresh_table)
+            refresh_after = True
         except (KafkaException, ValueError) as ex:
-            self.finish_loading_table()
             notify_error(self.app, "Kafka Error", ex)
+        finally:
+            self.finish_loading_table()
+            self._finish_mutation(refresh_after)
 
     def action_delete(self) -> None:
         if self.current_topic is None:
@@ -734,6 +856,7 @@ class ListTopics(Container):
         def on_dismiss(result: bool | None) -> None:
             if not result:
                 return
+            self._mutation_in_progress = True
             self.delete_topic(topic)
 
         self.app.push_screen(DeleteTopicScreen(topic), on_dismiss)
@@ -742,6 +865,7 @@ class ListTopics(Container):
     async def delete_topic(self, topic: Topic) -> None:
         """Delete a topic without blocking Textual's message loop."""
         self.start_loading_table()
+        refresh_after = False
         try:
             await make_it_async(self.topic_service.delete, topic.name)
             self.app.notify(
@@ -749,10 +873,24 @@ class ListTopics(Container):
                 title="Topic Deleted",
                 severity="information",
             )
-            self.set_timer(REFRESH_TABLE_DELAY, self.refresh_table)
+            refresh_after = True
         except KafkaException as ex:
-            self.finish_loading_table()
             notify_error(self.app, "Kafka Error", ex)
+        finally:
+            self.finish_loading_table()
+            self._finish_mutation(refresh_after)
+
+    def _finish_mutation(self, refresh_after: bool) -> None:
+        self._mutation_in_progress = False
+        if refresh_after:
+            self._refresh_pending = False
+            self.set_timer(
+                REFRESH_TABLE_DELAY,
+                lambda: self.request_refresh("mutation"),
+            )
+        elif self._refresh_pending:
+            self._refresh_pending = False
+            self.call_after_refresh(lambda: self.request_refresh("pending"))
 
     def action_describe(self) -> None:
         if self.current_topic is None:
@@ -772,7 +910,15 @@ class ListTopics(Container):
 
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
         """Disable contextual actions when their required state is unavailable."""
-        if action in {"delete", "describe", "edit"}:
+        if action == "describe":
+            return self.current_topic is not None and all(
+                state is MetricState.READY
+                for state in (
+                    self.current_topic.records_state,
+                    self.current_topic.groups_state,
+                )
+            )
+        if action in {"delete", "edit"}:
             return self.current_topic is not None
         if action == "all":
             return self.current_filter is not None
@@ -780,35 +926,90 @@ class ListTopics(Container):
 
     def fill_table(self) -> None:
         table = self.query_one(DataTable)
-        table.clear()
-        self.current_topic = None
-        self.refresh_bindings()
+        selected_topic_name = self.current_topic.name if self.current_topic is not None else None
+        visible_topics = [
+            topic
+            for topic in self.topics.values()
+            if self.current_filter is None or self.current_filter in topic.name
+        ]
+        desired_keys = [topic.name for topic in visible_topics]
+        current_keys = [str(row_key.value) for row_key in table.rows]
 
-        total_count = 0
-        for topic in self.topics.values():
-            if self.current_filter is not None and self.current_filter not in topic.name:
-                continue
-            total_count += 1
-            row = [
-                topic.name,
-                str(topic.partitions_count()),
-                str(topic.replicas_count()),
-                str(topic.isrs_count()),
-                str(topic.groups_count()),
-                str(topic.group_members_count()),
-                f"{APPROXIMATION}{topic.records_count()}",
-                f"{APPROXIMATION}{topic.lag()}",
-            ]
-            table.add_row(*row, key=topic.name)
+        if current_keys == desired_keys:
+            for topic in visible_topics:
+                for column_key, value in zip(
+                    (
+                        "name",
+                        "partitions",
+                        "replicas",
+                        "isrs",
+                        "groups",
+                        "members",
+                        "records",
+                        "lag",
+                    ),
+                    self._topic_row(topic),
+                ):
+                    table.update_cell(topic.name, column_key, value)
+        else:
+            table.clear()
+            for topic in visible_topics:
+                table.add_row(*self._topic_row(topic), key=topic.name)
+            if selected_topic_name in desired_keys:
+                table.move_cursor(row=desired_keys.index(selected_topic_name), animate=False)
+
+        if selected_topic_name in self.topics and selected_topic_name in desired_keys:
+            self.current_topic = self.topics[selected_topic_name]
+        elif desired_keys:
+            cursor_row = min(table.cursor_row, len(desired_keys) - 1)
+            self.current_topic = self.topics[desired_keys[cursor_row]]
+        else:
+            self.current_topic = None
+        self.refresh_bindings()
 
         border_title_filter_info = (
             rf"\[[{PRIMARY}]*{self.current_filter}*[/]]" if self.current_filter else ""
         )
         table.border_title = (
-            rf"[{PRIMARY}]Topics[/] {border_title_filter_info}\[[{PRIMARY}]{total_count}[/]]"
+            rf"[{PRIMARY}]Topics[/] {border_title_filter_info}"
+            rf"\[[{PRIMARY}]{len(visible_topics)}[/]]"
         )
-
         self.finish_loading_table()
+
+    def _topic_row(self, topic: Topic) -> list[str]:
+        return [
+            topic.name,
+            str(topic.partitions_count()),
+            str(topic.replicas_count()),
+            str(topic.isrs_count()),
+            self._metric(topic.groups_state, str(topic.groups_count())),
+            self._metric(topic.groups_state, str(topic.group_members_count())),
+            self._metric(
+                topic.records_state,
+                f"{APPROXIMATION}{topic.records_count()}",
+            ),
+            self._metric(topic.groups_state, f"{APPROXIMATION}{topic.lag()}"),
+        ]
+
+    @staticmethod
+    def _metric(state: MetricState, value: str) -> str:
+        if state is MetricState.READY:
+            return value
+        if state is MetricState.UNAVAILABLE:
+            return UNAVAILABLE_METRIC
+        return LOADING_METRIC
+
+    def _update_status(self, *, refreshing: bool) -> None:
+        table = self.query_one(DataTable)
+        interval = getattr(self.app, "auto_refresh_interval", 0)
+        auto_status = f"Auto {interval}s" if interval else "Auto Off"
+        if refreshing:
+            state = "Refreshing…"
+        elif self.last_updated_at is not None:
+            state = f"Updated {self.last_updated_at:%H:%M:%S}"
+        else:
+            state = "Not Updated"
+        table.border_subtitle = rf"\[[{PRIMARY}]Admin Mode · {state} · {auto_status}[/]]"
 
 
 class KaskadeAdmin(KaskadeApp):
@@ -818,6 +1019,51 @@ class KaskadeAdmin(KaskadeApp):
     def __init__(self, kafka_config: dict[str, Any]):
         super().__init__()
         self.kafka_config = kafka_config
+        self.auto_refresh_interval = self.keymap_settings.admin_refresh_interval_seconds
+        self._auto_refresh_timer: Any | None = None
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        if self.auto_refresh_interval:
+            self._auto_refresh_timer = self.set_interval(
+                self.auto_refresh_interval,
+                self._request_periodic_refresh,
+                name="admin-auto-refresh",
+                pause=True,
+            )
+        self.query_one(ListTopics).request_refresh("initial")
+
+    def push_screen(self, *args: Any, **kwargs: Any) -> Any:
+        self._pause_auto_refresh()
+        return super().push_screen(*args, **kwargs)
+
+    def pop_screen(self) -> Any:
+        returning_to_topics = len(self.screen_stack) == 2
+        result = super().pop_screen()
+        if returning_to_topics:
+            self.set_timer(0.1, self._resume_auto_refresh, name="resume-admin-auto-refresh")
+        return result
+
+    def _pause_auto_refresh(self) -> None:
+        if self._auto_refresh_timer is not None:
+            self._auto_refresh_timer.pause()
+
+    def _resume_auto_refresh(self) -> None:
+        if not self.auto_refresh_interval or len(self.screen_stack) != 1:
+            return
+        if self._auto_refresh_timer is not None:
+            self._auto_refresh_timer.resume()
+            self._auto_refresh_timer.reset()
+        self.query_one(ListTopics).request_refresh("resume")
+
+    def _request_periodic_refresh(self) -> None:
+        if len(self.screen_stack) == 1:
+            self.query_one(ListTopics).request_refresh("periodic")
+
+    def admin_refresh_completed(self) -> None:
+        if self._auto_refresh_timer is not None and len(self.screen_stack) == 1:
+            self._auto_refresh_timer.resume()
+            self._auto_refresh_timer.reset()
 
     def compose(self) -> ComposeResult:
         yield ListTopics(TopicService(self.kafka_config))

--- a/kaskade/admin.py
+++ b/kaskade/admin.py
@@ -1016,10 +1016,18 @@ class KaskadeAdmin(KaskadeApp):
     TITLE = "Kaskade Admin"
     AUTO_FOCUS = "#topics-table"
 
-    def __init__(self, kafka_config: dict[str, Any]):
+    def __init__(
+        self,
+        kafka_config: dict[str, Any],
+        refresh_interval: int | None = None,
+    ):
         super().__init__()
         self.kafka_config = kafka_config
-        self.auto_refresh_interval = self.keymap_settings.admin_refresh_interval_seconds
+        self.auto_refresh_interval = (
+            self.keymap_settings.admin_refresh_interval_seconds
+            if refresh_interval is None
+            else refresh_interval
+        )
         self._auto_refresh_timer: Any | None = None
 
     def on_mount(self) -> None:

--- a/kaskade/admin.py
+++ b/kaskade/admin.py
@@ -1,5 +1,7 @@
 import asyncio
+from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum, auto
 from time import perf_counter
 from typing import Any, ClassVar
 
@@ -53,6 +55,66 @@ EDIT_TOPIC_SHORTCUT = "e,ctrl+e"
 REFRESH_TOPICS_SHORTCUT = "ctrl+r"
 LOADING_METRIC = "…"
 UNAVAILABLE_METRIC = "—"
+TOPIC_COLUMN_KEYS = (
+    "name",
+    "partitions",
+    "replicas",
+    "isrs",
+    "groups",
+    "members",
+    "records",
+    "lag",
+)
+
+
+class RefreshReason(Enum):
+    INITIAL = auto()
+    MANUAL = auto()
+    PERIODIC = auto()
+    RESUME = auto()
+    MUTATION = auto()
+    PENDING = auto()
+
+
+@dataclass
+class RefreshCoordinator:
+    generation: int = 0
+    active: bool = False
+    pending: bool = False
+    mutation_active: bool = False
+
+    def request(self, reason: RefreshReason) -> int | None:
+        if self.active or self.mutation_active:
+            if reason is not RefreshReason.PERIODIC:
+                self.pending = True
+            return None
+        self.generation += 1
+        self.active = True
+        return self.generation
+
+    def is_current(self, generation: int) -> bool:
+        return self.active and generation == self.generation
+
+    def complete(self, generation: int) -> bool:
+        if not self.is_current(generation):
+            return False
+        self.active = False
+        return True
+
+    def take_pending(self) -> bool:
+        if not self.pending or self.active or self.mutation_active:
+            return False
+        self.pending = False
+        return True
+
+    def begin_mutation(self) -> None:
+        self.mutation_active = True
+
+    def end_mutation(self) -> None:
+        self.mutation_active = False
+
+    def discard_pending(self) -> None:
+        self.pending = False
 
 
 def _valid_topic_name(name: str) -> bool:
@@ -594,10 +656,7 @@ class ListTopics(Container):
         self.current_topic: Topic | None = None
         self.current_filter: str | None = None
         self.last_updated_at: datetime | None = None
-        self._refresh_generation = 0
-        self._refreshing = False
-        self._refresh_pending = False
-        self._mutation_in_progress = False
+        self.refresh_coordinator = RefreshCoordinator()
 
     def compose(self) -> ComposeResult:
         table: StretchyDataTable[str] = StretchyDataTable(
@@ -632,25 +691,14 @@ class ListTopics(Container):
         self.refresh_bindings()
 
     def action_refresh(self) -> None:
-        self.request_refresh("manual")
+        self.request_refresh(RefreshReason.MANUAL)
 
-    def request_refresh(self, reason: str) -> None:
-        if self._mutation_in_progress:
-            if reason != "periodic":
-                self._refresh_pending = True
-            return
-        if self._refreshing:
-            if reason == "manual":
-                self._start_refresh()
-            elif reason != "periodic":
-                self._refresh_pending = True
-            return
-        self._start_refresh()
+    def request_refresh(self, reason: RefreshReason) -> None:
+        generation = self.refresh_coordinator.request(reason)
+        if generation is not None:
+            self._start_refresh(generation)
 
-    def _start_refresh(self) -> None:
-        self._refresh_generation += 1
-        generation = self._refresh_generation
-        self._refreshing = True
+    def _start_refresh(self, generation: int) -> None:
         self._update_status(refreshing=True)
         self.refresh_topics(generation)
 
@@ -660,61 +708,77 @@ class ListTopics(Container):
         if not self.topics:
             table.loading = True
         started_at = perf_counter()
-        offsets_task: asyncio.Task[Any] | None = None
-        groups_task: asyncio.Task[Any] | None = None
+        stage_tasks: list[asyncio.Task[Any]] = []
 
         try:
-            refreshed_topics = await self.topic_service.metadata()
-            self._preserve_completed_metrics(refreshed_topics)
-            if generation != self._refresh_generation:
-                return
-
-            self.topics = refreshed_topics
-            self.fill_table()
-            table.loading = False
-
-            offsets_task = asyncio.create_task(self.topic_service.enrich_offsets(self.topics))
-            groups_task = asyncio.create_task(self.topic_service.load_groups())
-
-            offsets_result = await offsets_task
-            if generation != self._refresh_generation:
-                return
-            self.fill_table()
-            if offsets_result.errors:
-                self._notify_stage_failure("record metrics", len(offsets_result.errors))
-
-            groups_snapshot = await groups_task
-            if generation != self._refresh_generation:
-                return
-            groups_result = self.topic_service.apply_groups(self.topics, groups_snapshot)
-            self.fill_table()
-            if groups_result.errors:
-                self._notify_stage_failure("consumer-group metrics", len(groups_result.errors))
-
-            self.last_updated_at = datetime.now().astimezone()
-            logger.info(
-                "admin refresh completed topics=%d elapsed=%.3fs",
-                len(self.topics),
-                perf_counter() - started_at,
-            )
-        except KafkaException as ex:
-            notify_error(self.app, "Kafka Error", ex)
+            await self._run_refresh(generation, stage_tasks, started_at)
         except ADMIN_EXCEPTIONS as ex:
-            notify_error(self.app, "Refresh Error", ex)
+            title = "Kafka Error" if isinstance(ex, KafkaException) else "Refresh Error"
+            notify_error(self.app, title, ex)
         finally:
-            for task in (offsets_task, groups_task):
-                if task is not None and not task.done():
-                    task.cancel()
-            if generation == self._refresh_generation:
-                table.loading = False
-                self._refreshing = False
-                self._update_status(refreshing=False)
-                refresh_completed = getattr(self.app, "admin_refresh_completed", None)
-                if refresh_completed is not None:
-                    refresh_completed()
-                if self._refresh_pending and not self._mutation_in_progress:
-                    self._refresh_pending = False
-                    self.call_after_refresh(lambda: self.request_refresh("pending"))
+            await self._cancel_stage_tasks(stage_tasks)
+            self._complete_refresh(generation, table)
+
+    async def _run_refresh(
+        self,
+        generation: int,
+        stage_tasks: list[asyncio.Task[Any]],
+        started_at: float,
+    ) -> None:
+        refreshed_topics = await self.topic_service.metadata()
+        self._preserve_completed_metrics(refreshed_topics)
+        if not self.refresh_coordinator.is_current(generation):
+            return
+
+        self.topics = refreshed_topics
+        self.fill_table()
+        self.query_one(DataTable).loading = False
+        offsets_task = asyncio.create_task(self.topic_service.enrich_offsets(self.topics))
+        groups_task = asyncio.create_task(self.topic_service.load_groups())
+        stage_tasks.extend((offsets_task, groups_task))
+
+        failures: list[tuple[str, int]] = []
+        offsets_result = await offsets_task
+        if not self.refresh_coordinator.is_current(generation):
+            return
+        self.fill_table()
+        if offsets_result.errors:
+            failures.append(("record metrics", len(offsets_result.errors)))
+
+        groups_snapshot = await groups_task
+        if not self.refresh_coordinator.is_current(generation):
+            return
+        groups_result = self.topic_service.apply_groups(self.topics, groups_snapshot)
+        self.fill_table()
+        if groups_result.errors:
+            failures.append(("consumer-group metrics", len(groups_result.errors)))
+
+        self._notify_stage_failures(failures)
+        self.last_updated_at = datetime.now().astimezone()
+        logger.info(
+            "admin refresh completed topics=%d elapsed=%.3fs",
+            len(self.topics),
+            perf_counter() - started_at,
+        )
+
+    @staticmethod
+    async def _cancel_stage_tasks(stage_tasks: list[asyncio.Task[Any]]) -> None:
+        pending_tasks = [task for task in stage_tasks if not task.done()]
+        for task in pending_tasks:
+            task.cancel()
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+    def _complete_refresh(self, generation: int, table: DataTable[Any]) -> None:
+        if not self.refresh_coordinator.complete(generation):
+            return
+        table.loading = False
+        self._update_status(refreshing=False)
+        refresh_completed = getattr(self.app, "admin_refresh_completed", None)
+        if refresh_completed is not None:
+            refresh_completed()
+        if self.refresh_coordinator.take_pending():
+            self.call_after_refresh(lambda: self.request_refresh(RefreshReason.PENDING))
 
     def _preserve_completed_metrics(self, refreshed_topics: dict[str, Topic]) -> None:
         for topic_name, refreshed_topic in refreshed_topics.items():
@@ -738,9 +802,14 @@ class ListTopics(Container):
                 refreshed_topic.groups = previous_topic.groups
                 refreshed_topic.groups_state = MetricState.READY
 
-    def _notify_stage_failure(self, stage: str, error_count: int) -> None:
+    def _notify_stage_failures(self, failures: list[tuple[str, int]]) -> None:
+        if not failures:
+            return
+        failure_summary = ", ".join(
+            f"{stage} ({error_count} failed request(s))" for stage, error_count in failures
+        )
         self.app.notify(
-            f"Could not refresh {stage} ({error_count} failed request(s)).",
+            f"Could not refresh {failure_summary}.",
             title="Partial Refresh",
             severity="warning",
         )
@@ -749,7 +818,7 @@ class ListTopics(Container):
         def on_dismiss(result: NewTopic | None) -> None:
             if result is None:
                 return
-            self._mutation_in_progress = True
+            self.refresh_coordinator.begin_mutation()
             self.create_topic(result)
 
         self.app.push_screen(CreateTopicScreen(), on_dismiss)
@@ -811,7 +880,7 @@ class ListTopics(Container):
         def on_dismiss(result: bool | None) -> None:
             if not result:
                 return
-            self._mutation_in_progress = True
+            self.refresh_coordinator.begin_mutation()
             self.update_topic(topic, edit_topic_screen)
 
         self.app.push_screen(edit_topic_screen, on_dismiss)
@@ -856,7 +925,7 @@ class ListTopics(Container):
         def on_dismiss(result: bool | None) -> None:
             if not result:
                 return
-            self._mutation_in_progress = True
+            self.refresh_coordinator.begin_mutation()
             self.delete_topic(topic)
 
         self.app.push_screen(DeleteTopicScreen(topic), on_dismiss)
@@ -881,16 +950,15 @@ class ListTopics(Container):
             self._finish_mutation(refresh_after)
 
     def _finish_mutation(self, refresh_after: bool) -> None:
-        self._mutation_in_progress = False
+        self.refresh_coordinator.end_mutation()
         if refresh_after:
-            self._refresh_pending = False
+            self.refresh_coordinator.discard_pending()
             self.set_timer(
                 REFRESH_TABLE_DELAY,
-                lambda: self.request_refresh("mutation"),
+                lambda: self.request_refresh(RefreshReason.MUTATION),
             )
-        elif self._refresh_pending:
-            self._refresh_pending = False
-            self.call_after_refresh(lambda: self.request_refresh("pending"))
+        elif self.refresh_coordinator.take_pending():
+            self.call_after_refresh(lambda: self.request_refresh(RefreshReason.PENDING))
 
     def action_describe(self) -> None:
         if self.current_topic is None:
@@ -927,37 +995,45 @@ class ListTopics(Container):
     def fill_table(self) -> None:
         table = self.query_one(DataTable)
         selected_topic_name = self.current_topic.name if self.current_topic is not None else None
-        visible_topics = [
+        visible_topics = self._visible_topics()
+        desired_keys = [topic.name for topic in visible_topics]
+        self._render_topic_rows(table, visible_topics, desired_keys, selected_topic_name)
+        self._restore_selection(table, desired_keys, selected_topic_name)
+        self._update_table_title(table, len(visible_topics))
+        self.finish_loading_table()
+
+    def _visible_topics(self) -> list[Topic]:
+        return [
             topic
             for topic in self.topics.values()
             if self.current_filter is None or self.current_filter in topic.name
         ]
-        desired_keys = [topic.name for topic in visible_topics]
-        current_keys = [str(row_key.value) for row_key in table.rows]
 
+    def _render_topic_rows(
+        self,
+        table: DataTable[Any],
+        visible_topics: list[Topic],
+        desired_keys: list[str],
+        selected_topic_name: str | None,
+    ) -> None:
+        current_keys = [str(row_key.value) for row_key in table.rows]
         if current_keys == desired_keys:
             for topic in visible_topics:
-                for column_key, value in zip(
-                    (
-                        "name",
-                        "partitions",
-                        "replicas",
-                        "isrs",
-                        "groups",
-                        "members",
-                        "records",
-                        "lag",
-                    ),
-                    self._topic_row(topic),
-                ):
+                for column_key, value in zip(TOPIC_COLUMN_KEYS, self._topic_row(topic)):
                     table.update_cell(topic.name, column_key, value)
-        else:
-            table.clear()
-            for topic in visible_topics:
-                table.add_row(*self._topic_row(topic), key=topic.name)
-            if selected_topic_name in desired_keys:
-                table.move_cursor(row=desired_keys.index(selected_topic_name), animate=False)
+            return
+        table.clear()
+        for topic in visible_topics:
+            table.add_row(*self._topic_row(topic), key=topic.name)
+        if selected_topic_name in desired_keys:
+            table.move_cursor(row=desired_keys.index(selected_topic_name), animate=False)
 
+    def _restore_selection(
+        self,
+        table: DataTable[Any],
+        desired_keys: list[str],
+        selected_topic_name: str | None,
+    ) -> None:
         if selected_topic_name in self.topics and selected_topic_name in desired_keys:
             self.current_topic = self.topics[selected_topic_name]
         elif desired_keys:
@@ -967,14 +1043,14 @@ class ListTopics(Container):
             self.current_topic = None
         self.refresh_bindings()
 
+    def _update_table_title(self, table: DataTable[Any], visible_topic_count: int) -> None:
         border_title_filter_info = (
             rf"\[[{PRIMARY}]*{self.current_filter}*[/]]" if self.current_filter else ""
         )
         table.border_title = (
             rf"[{PRIMARY}]Topics[/] {border_title_filter_info}"
-            rf"\[[{PRIMARY}]{len(visible_topics)}[/]]"
+            rf"\[[{PRIMARY}]{visible_topic_count}[/]]"
         )
-        self.finish_loading_table()
 
     def _topic_row(self, topic: Topic) -> list[str]:
         return [
@@ -1039,7 +1115,7 @@ class KaskadeAdmin(KaskadeApp):
                 name="admin-auto-refresh",
                 pause=True,
             )
-        self.query_one(ListTopics).request_refresh("initial")
+        self.query_one(ListTopics).request_refresh(RefreshReason.INITIAL)
 
     def push_screen(self, *args: Any, **kwargs: Any) -> Any:
         self._pause_auto_refresh()
@@ -1062,11 +1138,11 @@ class KaskadeAdmin(KaskadeApp):
         if self._auto_refresh_timer is not None:
             self._auto_refresh_timer.resume()
             self._auto_refresh_timer.reset()
-        self.query_one(ListTopics).request_refresh("resume")
+        self.query_one(ListTopics).request_refresh(RefreshReason.RESUME)
 
     def _request_periodic_refresh(self) -> None:
         if len(self.screen_stack) == 1:
-            self.query_one(ListTopics).request_refresh("periodic")
+            self.query_one(ListTopics).request_refresh(RefreshReason.PERIODIC)
 
     def admin_refresh_completed(self) -> None:
         if self._auto_refresh_timer is not None and len(self.screen_stack) == 1:

--- a/kaskade/deserializers.py
+++ b/kaskade/deserializers.py
@@ -127,14 +127,7 @@ class JsonDeserializer(Deserializer):
     def deserialize(
         self, data: bytes, topic: str | None = None, context: MessageField = MessageField.NONE
     ) -> Any:
-        if len(data) > 5:
-            magic, _schema_id = unpack(">bI", data[:5])
-            if magic == SCHEMA_REGISTRY_MAGIC_BYTE:
-                # in case that the json has a confluent schema registry magic byte
-                # https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
-                return json.loads(data[5:])
-
-        return json.loads(data)
+        return json.loads(_without_confluent_header(data))
 
 
 class RegistryDeserializer(Deserializer):
@@ -203,14 +196,7 @@ class AvroDeserializer(Deserializer):
         if schema_path is None:
             raise DeserializationError("Avro schema file not found")
 
-        if len(data) > 5:
-            magic, _schema_id = unpack(">bI", data[:5])
-            if magic == SCHEMA_REGISTRY_MAGIC_BYTE:
-                # in case that the avro has a confluent schema registry magic byte
-                # https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
-                return avro_to_py(schema_path, data[5:])
-
-        return avro_to_py(schema_path, data)
+        return avro_to_py(schema_path, _without_confluent_header(data))
 
 
 class ProtobufDeserializer(Deserializer):
@@ -225,47 +211,48 @@ class ProtobufDeserializer(Deserializer):
     ) -> Any:
         if topic is None:
             raise DeserializationError("Topic name needed")
+        message_class = self._message_class(context)
+        if _has_confluent_header(data):
+            return self._deserialize_confluent(data, topic, context, message_class)
 
-        if context == MessageField.NONE:
-            raise DeserializationError("Context is needed: KEY or VALUE")
+        new_message = message_class()
+        new_message.ParseFromString(data)
+        return MessageToDict(new_message, always_print_fields_with_no_presence=True)
 
+    def _message_class(self, context: MessageField) -> type[Message]:
+        class_name = self._class_name(context)
         if self.descriptor_path is None:
             raise DeserializationError("Descriptor not found")
-
         if self.descriptor_classes is None:
             descriptor = FileDescriptorSet.FromString(file_to_bytes(self.descriptor_path))
             self.descriptor_classes = GetMessages(descriptor.file)
-
-        deserialization_class: type[Message] | None = None
-
-        if context == MessageField.KEY:
-            if self.key_class is None:
-                raise DeserializationError("Protobuf message name not provided for context KEY")
-            deserialization_class = self.descriptor_classes.get(self.key_class)
-
-        if context == MessageField.VALUE:
-            if self.value_class is None:
-                raise DeserializationError("Protobuf message name not provided for context VALUE")
-            deserialization_class = self.descriptor_classes.get(self.value_class)
-
-        if deserialization_class is None:
+        message_class = self.descriptor_classes.get(class_name)
+        if message_class is None:
             raise DeserializationError("Deserialization class not found")
+        return message_class
 
-        if len(data) > 5:
-            magic, _schema_id = unpack(">bI", data[:5])
-            if magic == SCHEMA_REGISTRY_MAGIC_BYTE:
-                # in case that the protobuf has a confluent schema registry magic byte
-                # https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
-                deserializer_config = {"use.deprecated.format": False}
-                protobuf_deserializer = ConfluentProtobufDeserializer(
-                    deserialization_class, deserializer_config
-                )
-                new_message = protobuf_deserializer(data, SerializationContext(topic, context))
-                return MessageToDict(new_message, always_print_fields_with_no_presence=True)
+    def _class_name(self, context: MessageField) -> str:
+        if context == MessageField.NONE:
+            raise DeserializationError("Context is needed: KEY or VALUE")
+        class_name = self.key_class if context == MessageField.KEY else self.value_class
+        if class_name is None:
+            raise DeserializationError(
+                f"Protobuf message name not provided for context {context.name}"
+            )
+        return class_name
 
-        new_message = deserialization_class()
-        new_message.ParseFromString(data)
-        return MessageToDict(new_message, always_print_fields_with_no_presence=True)
+    @staticmethod
+    def _deserialize_confluent(
+        data: bytes,
+        topic: str,
+        context: MessageField,
+        message_class: type[Message],
+    ) -> Any:
+        deserializer = ConfluentProtobufDeserializer(
+            message_class, {"use.deprecated.format": False}
+        )
+        message = deserializer(data, SerializationContext(topic, context))
+        return MessageToDict(message, always_print_fields_with_no_presence=True)
 
 
 class DeserializerPool:
@@ -296,34 +283,37 @@ class DeserializerPool:
         self.boolean_deserializer = BooleanDeserializer()
         self.long_deserializer = LongDeserializer()
         self.default_deserializer = DefaultDeserializer()
+        self._deserializers: dict[Deserialization, Deserializer | None] = {
+            Deserialization.STRING: self.string_deserializer,
+            Deserialization.JSON: self.json_deserializer,
+            Deserialization.INTEGER: self.integer_deserializer,
+            Deserialization.LONG: self.long_deserializer,
+            Deserialization.DOUBLE: self.double_deserializer,
+            Deserialization.FLOAT: self.float_deserializer,
+            Deserialization.BOOLEAN: self.boolean_deserializer,
+            Deserialization.REGISTRY: self.registry_deserializer,
+            Deserialization.AVRO: self.avro_deserializer,
+            Deserialization.PROTOBUF: self.protobuf_deserializer,
+        }
 
     def get(self, deserialization_format: Deserialization) -> Deserializer:
-        match deserialization_format:
-            case Deserialization.STRING:
-                return self.string_deserializer
-            case Deserialization.JSON:
-                return self.json_deserializer
-            case Deserialization.INTEGER:
-                return self.integer_deserializer
-            case Deserialization.LONG:
-                return self.long_deserializer
-            case Deserialization.DOUBLE:
-                return self.double_deserializer
-            case Deserialization.FLOAT:
-                return self.float_deserializer
-            case Deserialization.BOOLEAN:
-                return self.boolean_deserializer
-            case Deserialization.REGISTRY:
-                if self.registry_deserializer is None:
-                    raise DeserializationError("Schema Registry is not configured")
-                return self.registry_deserializer
-            case Deserialization.AVRO:
-                if self.avro_deserializer is None:
-                    raise DeserializationError("Avro is not configured")
-                return self.avro_deserializer
-            case Deserialization.PROTOBUF:
-                if self.protobuf_deserializer is None:
-                    raise DeserializationError("Protobuf is not configured")
-                return self.protobuf_deserializer
-            case _:
-                return self.default_deserializer
+        deserializer = self._deserializers.get(deserialization_format, self.default_deserializer)
+        if deserializer is None:
+            configured_name = {
+                Deserialization.REGISTRY: "Schema Registry",
+                Deserialization.AVRO: "Avro",
+                Deserialization.PROTOBUF: "Protobuf",
+            }[deserialization_format]
+            raise DeserializationError(f"{configured_name} is not configured")
+        return deserializer
+
+
+def _has_confluent_header(data: bytes) -> bool:
+    if len(data) <= 5:
+        return False
+    magic = int(unpack(">bI", data[:5])[0])
+    return magic == SCHEMA_REGISTRY_MAGIC_BYTE
+
+
+def _without_confluent_header(data: bytes) -> bytes:
+    return data[5:] if _has_confluent_header(data) else data

--- a/kaskade/keymaps.py
+++ b/kaskade/keymaps.py
@@ -8,6 +8,8 @@ from textual.keys import KEY_NAME_REPLACEMENTS, KEY_TO_UNICODE_NAME, Keys, key_t
 
 CONFIG_ENV_VAR = "KASKADE_CONFIG"
 CONFIG_FILE_NAME = "config.yaml"
+DEFAULT_ADMIN_REFRESH_INTERVAL_SECONDS = 30
+MIN_ADMIN_REFRESH_INTERVAL_SECONDS = 5
 
 NAVIGATION_BINDING_IDS = frozenset(
     {
@@ -75,6 +77,7 @@ _NAMED_KEYS = (
 class KeymapSettings:
     path: Path
     keymap: dict[str, str]
+    admin_refresh_interval_seconds: int = DEFAULT_ADMIN_REFRESH_INTERVAL_SECONDS
     warnings: tuple[str, ...] = ()
 
 
@@ -92,7 +95,7 @@ def default_config_path(environ: Mapping[str, str] | None = None, home: Path | N
 
 
 def load_keymap(path: Path | None = None) -> KeymapSettings:
-    """Load valid Textual binding overrides without making startup fragile."""
+    """Load valid application settings without making startup fragile."""
     config_path = default_config_path() if path is None else path
     if not config_path.exists():
         return KeymapSettings(config_path, {})
@@ -103,7 +106,7 @@ def load_keymap(path: Path | None = None) -> KeymapSettings:
         return KeymapSettings(
             config_path,
             {},
-            (f"Could not read {config_path}: {ex}",),
+            warnings=(f"Could not read {config_path}: {ex}",),
         )
 
     if data is None:
@@ -112,19 +115,16 @@ def load_keymap(path: Path | None = None) -> KeymapSettings:
         return KeymapSettings(
             config_path,
             {},
-            (f"Ignoring {config_path}: the document must be a mapping.",),
+            warnings=(f"Ignoring {config_path}: the document must be a mapping.",),
         )
 
     configured_keymap = data.get("keymap", {})
+    warning_messages: list[str] = []
     if not isinstance(configured_keymap, dict):
-        return KeymapSettings(
-            config_path,
-            {},
-            (f"Ignoring {config_path}: 'keymap' must be a mapping.",),
-        )
+        warning_messages.append(f"Ignoring {config_path}: 'keymap' must be a mapping.")
+        configured_keymap = {}
 
     keymap: dict[str, str] = {}
-    warning_messages: list[str] = []
     for binding_id, keys in configured_keymap.items():
         if not isinstance(binding_id, str) or binding_id not in KNOWN_BINDING_IDS:
             warning_messages.append(f"Ignoring unknown binding ID: {binding_id!r}.")
@@ -140,7 +140,30 @@ def load_keymap(path: Path | None = None) -> KeymapSettings:
             continue
         keymap[binding_id] = keys
 
-    return KeymapSettings(config_path, keymap, tuple(warning_messages))
+    refresh_interval = DEFAULT_ADMIN_REFRESH_INTERVAL_SECONDS
+    configured_admin = data.get("admin", {})
+    if not isinstance(configured_admin, dict):
+        warning_messages.append("Ignoring 'admin': it must be a mapping.")
+    elif "refresh_interval_seconds" in configured_admin:
+        configured_interval = configured_admin["refresh_interval_seconds"]
+        if not isinstance(configured_interval, int) or isinstance(configured_interval, bool):
+            warning_messages.append(
+                "Ignoring 'admin.refresh_interval_seconds': it must be an integer."
+            )
+        elif configured_interval != 0 and configured_interval < MIN_ADMIN_REFRESH_INTERVAL_SECONDS:
+            warning_messages.append(
+                "Ignoring 'admin.refresh_interval_seconds': it must be 0 or at least "
+                f"{MIN_ADMIN_REFRESH_INTERVAL_SECONDS}."
+            )
+        else:
+            refresh_interval = configured_interval
+
+    return KeymapSettings(
+        config_path,
+        keymap,
+        admin_refresh_interval_seconds=refresh_interval,
+        warnings=tuple(warning_messages),
+    )
 
 
 def _is_valid_key(key: str) -> bool:

--- a/kaskade/keymaps.py
+++ b/kaskade/keymaps.py
@@ -2,6 +2,7 @@ import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import yaml
 from textual.keys import KEY_NAME_REPLACEMENTS, KEY_TO_UNICODE_NAME, Keys, key_to_character
@@ -74,11 +75,15 @@ _NAMED_KEYS = (
 
 
 @dataclass(frozen=True)
-class KeymapSettings:
+class AppSettings:
     path: Path
     keymap: dict[str, str]
     admin_refresh_interval_seconds: int = DEFAULT_ADMIN_REFRESH_INTERVAL_SECONDS
     warnings: tuple[str, ...] = ()
+
+
+# Compatibility name retained for callers that imported the original settings type.
+KeymapSettings = AppSettings
 
 
 def default_config_path(environ: Mapping[str, str] | None = None, home: Path | None = None) -> Path:
@@ -94,31 +99,48 @@ def default_config_path(environ: Mapping[str, str] | None = None, home: Path | N
     return base_path / "kaskade" / CONFIG_FILE_NAME
 
 
-def load_keymap(path: Path | None = None) -> KeymapSettings:
+def load_settings(path: Path | None = None) -> AppSettings:
     """Load valid application settings without making startup fragile."""
     config_path = default_config_path() if path is None else path
+    data, read_warnings = _read_config(config_path)
+    keymap, keymap_warnings = _parse_keymap(data.get("keymap", {}), config_path)
+    refresh_interval, admin_warnings = _parse_admin_settings(data.get("admin", {}))
+    return AppSettings(
+        config_path,
+        keymap,
+        admin_refresh_interval_seconds=refresh_interval,
+        warnings=(*read_warnings, *keymap_warnings, *admin_warnings),
+    )
+
+
+def load_keymap(path: Path | None = None) -> AppSettings:
+    """Compatibility wrapper for the original application settings loader."""
+    return load_settings(path)
+
+
+def is_valid_admin_refresh_interval(value: int) -> bool:
+    return value == 0 or value >= MIN_ADMIN_REFRESH_INTERVAL_SECONDS
+
+
+def _read_config(config_path: Path) -> tuple[dict[str, Any], tuple[str, ...]]:
     if not config_path.exists():
-        return KeymapSettings(config_path, {})
+        return {}, ()
 
     try:
         data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     except (OSError, yaml.YAMLError) as ex:
-        return KeymapSettings(
-            config_path,
-            {},
-            warnings=(f"Could not read {config_path}: {ex}",),
-        )
+        return {}, (f"Could not read {config_path}: {ex}",)
 
     if data is None:
-        return KeymapSettings(config_path, {})
+        return {}, ()
     if not isinstance(data, dict):
-        return KeymapSettings(
-            config_path,
-            {},
-            warnings=(f"Ignoring {config_path}: the document must be a mapping.",),
-        )
+        return {}, (f"Ignoring {config_path}: the document must be a mapping.",)
+    return data, ()
 
-    configured_keymap = data.get("keymap", {})
+
+def _parse_keymap(
+    configured_keymap: Any, config_path: Path
+) -> tuple[dict[str, str], tuple[str, ...]]:
     warning_messages: list[str] = []
     if not isinstance(configured_keymap, dict):
         warning_messages.append(f"Ignoring {config_path}: 'keymap' must be a mapping.")
@@ -139,9 +161,12 @@ def load_keymap(path: Path | None = None) -> KeymapSettings:
             )
             continue
         keymap[binding_id] = keys
+    return keymap, tuple(warning_messages)
 
+
+def _parse_admin_settings(configured_admin: Any) -> tuple[int, tuple[str, ...]]:
     refresh_interval = DEFAULT_ADMIN_REFRESH_INTERVAL_SECONDS
-    configured_admin = data.get("admin", {})
+    warning_messages: list[str] = []
     if not isinstance(configured_admin, dict):
         warning_messages.append("Ignoring 'admin': it must be a mapping.")
     elif "refresh_interval_seconds" in configured_admin:
@@ -150,20 +175,14 @@ def load_keymap(path: Path | None = None) -> KeymapSettings:
             warning_messages.append(
                 "Ignoring 'admin.refresh_interval_seconds': it must be an integer."
             )
-        elif configured_interval != 0 and configured_interval < MIN_ADMIN_REFRESH_INTERVAL_SECONDS:
+        elif not is_valid_admin_refresh_interval(configured_interval):
             warning_messages.append(
                 "Ignoring 'admin.refresh_interval_seconds': it must be 0 or at least "
                 f"{MIN_ADMIN_REFRESH_INTERVAL_SECONDS}."
             )
         else:
             refresh_interval = configured_interval
-
-    return KeymapSettings(
-        config_path,
-        keymap,
-        admin_refresh_interval_seconds=refresh_interval,
-        warnings=tuple(warning_messages),
-    )
+    return refresh_interval, tuple(warning_messages)
 
 
 def _is_valid_key(key: str) -> bool:

--- a/kaskade/main.py
+++ b/kaskade/main.py
@@ -16,6 +16,7 @@ from kaskade.configs import (
 )
 from kaskade.consumer import KaskadeConsumer
 from kaskade.deserializers import Deserialization
+from kaskade.keymaps import MIN_ADMIN_REFRESH_INTERVAL_SECONDS
 from kaskade.themes import DEFAULT_THEME, available_theme_names
 from kaskade.utils import load_properties
 
@@ -45,6 +46,16 @@ def string_to_deserializer_type(ctx: Any, param: Any, value: Any) -> Any:
     return Deserialization.from_str(value)
 
 
+def validate_admin_refresh_interval(ctx: Any, param: Any, value: int | None) -> int | None:
+    if value is not None and value != 0 and value < MIN_ADMIN_REFRESH_INTERVAL_SECONDS:
+        raise BadParameter(
+            message=f"Should be 0 or at least {MIN_ADMIN_REFRESH_INTERVAL_SECONDS} seconds.",
+            ctx=ctx,
+            param=param,
+        )
+    return value
+
+
 @cloup.group(epilog=EPILOG_HELP)
 @cloup.version_option(APP_VERSION)
 def cli() -> None:
@@ -58,6 +69,13 @@ def cli() -> None:
     default=DEFAULT_THEME,
     show_default=True,
     help="Textual theme to use.",
+)
+@cloup.option(
+    "--refresh-interval",
+    type=int,
+    callback=validate_admin_refresh_interval,
+    metavar="seconds",
+    help="Admin auto-refresh interval. Use 0 to disable; overrides config.yaml.",
 )
 @cloup.option_group(
     "Kafka options",
@@ -91,6 +109,7 @@ def admin(
     kafka_config_file: str | None,
     kafka_config: dict[str, str],
     theme: str,
+    refresh_interval: int | None,
 ) -> None:
     """
     Administrator mode.
@@ -98,6 +117,7 @@ def admin(
     \b
     Examples:
       kaskade admin -b localhost:9092
+      kaskade admin -b localhost:9092 --refresh-interval 10
       kaskade admin -b localhost:9092 --config security.protocol=SSL
       kaskade admin -b localhost:9092 --config-file kafka.properties
     """
@@ -107,7 +127,7 @@ def admin(
 
     kafka_config[BOOTSTRAP_SERVERS] = bootstrap_servers
 
-    kaskade_app = KaskadeAdmin(kafka_config)
+    kaskade_app = KaskadeAdmin(kafka_config, refresh_interval=refresh_interval)
     kaskade_app.theme = theme
     kaskade_app.run()
 

--- a/kaskade/main.py
+++ b/kaskade/main.py
@@ -16,7 +16,10 @@ from kaskade.configs import (
 )
 from kaskade.consumer import KaskadeConsumer
 from kaskade.deserializers import Deserialization
-from kaskade.keymaps import MIN_ADMIN_REFRESH_INTERVAL_SECONDS
+from kaskade.keymaps import (
+    MIN_ADMIN_REFRESH_INTERVAL_SECONDS,
+    is_valid_admin_refresh_interval,
+)
 from kaskade.themes import DEFAULT_THEME, available_theme_names
 from kaskade.utils import load_properties
 
@@ -47,7 +50,7 @@ def string_to_deserializer_type(ctx: Any, param: Any, value: Any) -> Any:
 
 
 def validate_admin_refresh_interval(ctx: Any, param: Any, value: int | None) -> int | None:
-    if value is not None and value != 0 and value < MIN_ADMIN_REFRESH_INTERVAL_SECONDS:
+    if value is not None and not is_valid_admin_refresh_interval(value):
         raise BadParameter(
             message=f"Should be 0 or at least {MIN_ADMIN_REFRESH_INTERVAL_SECONDS} seconds.",
             ctx=ctx,

--- a/kaskade/models.py
+++ b/kaskade/models.py
@@ -5,6 +5,8 @@ from confluent_kafka.serialization import MessageField
 
 from kaskade.deserializers import DESERIALIZATION_EXCEPTIONS, Deserialization, Deserializer
 
+_NOT_DESERIALIZED = object()
+
 
 class Node:
     def __init__(
@@ -190,6 +192,8 @@ class Topic:
         name: str = "",
         partitions: None | list[Partition] = None,
         groups: None | list[Group] = None,
+        records_state: "MetricState | None" = None,
+        groups_state: "MetricState | None" = None,
     ) -> None:
         if groups is None:
             groups = []
@@ -198,6 +202,8 @@ class Topic:
         self.name = name
         self.partitions = partitions
         self.groups = groups
+        self.records_state = records_state or MetricState.LOADING
+        self.groups_state = groups_state or MetricState.LOADING
 
     def partitions_count(self) -> int:
         return len(self.partitions) if self.partitions is not None else 0
@@ -290,6 +296,12 @@ class CleanupPolicy(Enum):
         return [str(policy) for policy in CleanupPolicy]
 
 
+class MetricState(Enum):
+    LOADING = auto()
+    READY = auto()
+    UNAVAILABLE = auto()
+
+
 class Header:
     def __init__(
         self,
@@ -300,6 +312,7 @@ class Header:
         self.key = key
         self.value = value
         self.value_deserializer = value_deserializer
+        self._deserialized: Any = _NOT_DESERIALIZED
 
     def __repr__(self) -> str:
         return str(self)
@@ -313,17 +326,23 @@ class Header:
         return False
 
     def value_deserialized(self) -> Any:
+        if self._deserialized is not _NOT_DESERIALIZED:
+            return self._deserialized
+
         if self.value is None:
-            return
+            self._deserialized = None
+            return self._deserialized
 
         if self.value_deserializer is None:
-            return str(self.value)
+            self._deserialized = str(self.value)
+            return self._deserialized
 
         try:
-            return self.value_deserializer.deserialize(self.value)
+            self._deserialized = self.value_deserializer.deserialize(self.value)
         except DESERIALIZATION_EXCEPTIONS:
             # it doesn't matter to show the binaries
-            return str(self.value)
+            self._deserialized = str(self.value)
+        return self._deserialized
 
     def value_str(self) -> str:
         return str(self.value_deserialized())
@@ -357,6 +376,8 @@ class Record:
         self.value_deserialization = value_deserialization
         self.key_deserializer = key_deserializer
         self.value_deserializer = value_deserializer
+        self._key_deserialized: Any = _NOT_DESERIALIZED
+        self._value_deserialized: Any = _NOT_DESERIALIZED
 
     def __repr__(self) -> str:
         return str(self)
@@ -390,22 +411,38 @@ class Record:
         }
 
     def key_deserialized(self) -> Any:
+        if self._key_deserialized is not _NOT_DESERIALIZED:
+            return self._key_deserialized
+
         if self.key is None:
-            return
+            self._key_deserialized = None
+            return self._key_deserialized
 
         if self.key_deserializer is None:
-            return str(self.key)
+            self._key_deserialized = str(self.key)
+            return self._key_deserialized
 
-        return self.key_deserializer.deserialize(self.key, self.topic, MessageField.KEY)
+        self._key_deserialized = self.key_deserializer.deserialize(
+            self.key, self.topic, MessageField.KEY
+        )
+        return self._key_deserialized
 
     def value_deserialized(self) -> Any:
+        if self._value_deserialized is not _NOT_DESERIALIZED:
+            return self._value_deserialized
+
         if self.value is None:
-            return
+            self._value_deserialized = None
+            return self._value_deserialized
 
         if self.value_deserializer is None:
-            return str(self.value)
+            self._value_deserialized = str(self.value)
+            return self._value_deserialized
 
-        return self.value_deserializer.deserialize(self.value, self.topic, MessageField.VALUE)
+        self._value_deserialized = self.value_deserializer.deserialize(
+            self.value, self.topic, MessageField.VALUE
+        )
+        return self._value_deserialized
 
     def key_str(self) -> str:
         return str(self.key_deserialized())

--- a/kaskade/services.py
+++ b/kaskade/services.py
@@ -1,6 +1,6 @@
 import asyncio
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from time import perf_counter
 from typing import Any
@@ -86,6 +86,9 @@ class ConsumerService:
         )
         self.consumer.subscribe([topic], on_assign=self.on_assign)
         self.deserializer_factory = deserializer_factory
+        self.key_deserializer = deserializer_factory.get(key_deserialization)
+        self.value_deserializer = deserializer_factory.get(value_deserialization)
+        self.header_deserializer = deserializer_factory.get(Deserialization.STRING)
 
     def on_assign(self, consumer: Consumer, partitions: list[TopicPartition]) -> None:
         self.stable = True
@@ -116,13 +119,11 @@ class ConsumerService:
         scanned_records = 0
         first_record_at: float | None = None
 
-        while len(records) < self.page_size:
-            if poll_retries >= self.poll_retries:
-                break
-
-            if stabilization_retries >= self.stabilization_retries:
-                break
-
+        while (
+            len(records) < self.page_size
+            and poll_retries < self.poll_retries
+            and stabilization_retries < self.stabilization_retries
+        ):
             record_batch = await make_it_async(
                 self.consumer.consume,
                 self.page_size - len(records),
@@ -140,68 +141,18 @@ class ConsumerService:
             poll_retries = 0
 
             for record_metadata in record_batch:
-                if record_metadata.error():
-                    raise KafkaException(record_metadata.error())
-
                 scanned_records += 1
                 if first_record_at is None:
                     first_record_at = perf_counter()
-
-                timestamp_available, timestamp = record_metadata.timestamp()
-                date = (
-                    datetime.fromtimestamp(timestamp / 1000, tz=timezone.utc)
-                    .astimezone()
-                    .strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
-                    if timestamp_available > 0
-                    else ""
-                )
-
-                record = Record(
-                    topic=self.topic,
-                    partition=record_metadata.partition(),
-                    offset=record_metadata.offset(),
-                    key=record_metadata.key(),
-                    value=record_metadata.value(),
-                    date=date,
-                    headers=(
-                        [
-                            Header(
-                                key=key,
-                                value=value,
-                                value_deserializer=self.deserializer_factory.get(
-                                    Deserialization.STRING
-                                ),
-                            )
-                            for key, value in record_metadata.headers()
-                        ]
-                        if record_metadata.headers() is not None
-                        else []
-                    ),
-                    key_deserialization=self.key_deserialization,
-                    value_deserialization=self.value_deserialization,
-                    key_deserializer=self.deserializer_factory.get(self.key_deserialization),
-                    value_deserializer=self.deserializer_factory.get(self.value_deserialization),
-                )
-
-                if partition_filter is not None and record.partition != partition_filter:
-                    continue
-
-                if key_filter and key_filter not in record.key_str():
-                    continue
-
-                if value_filter and value_filter not in record.value_str():
-                    continue
-
-                if header_filter:
-                    if record.headers is None:
-                        continue
-
-                    if not [
-                        header for header in record.headers if header_filter in header.value_str()
-                    ]:
-                        continue
-
-                records.append(record)
+                record = self._record_from_message(record_metadata)
+                if self._matches(
+                    record,
+                    partition_filter=partition_filter,
+                    key_filter=key_filter,
+                    value_filter=value_filter,
+                    header_filter=header_filter,
+                ):
+                    records.append(record)
                 if len(records) >= self.page_size:
                     break
 
@@ -216,6 +167,56 @@ class ConsumerService:
         )
 
         return records
+
+    def _record_from_message(self, message: Any) -> Record:
+        if message.error():
+            raise KafkaException(message.error())
+        return Record(
+            topic=self.topic,
+            partition=message.partition(),
+            offset=message.offset(),
+            key=message.key(),
+            value=message.value(),
+            date=self._message_date(message),
+            headers=[
+                Header(key=key, value=value, value_deserializer=self.header_deserializer)
+                for key, value in (message.headers() or [])
+            ],
+            key_deserialization=self.key_deserialization,
+            value_deserialization=self.value_deserialization,
+            key_deserializer=self.key_deserializer,
+            value_deserializer=self.value_deserializer,
+        )
+
+    @staticmethod
+    def _message_date(message: Any) -> str:
+        timestamp_available, timestamp = message.timestamp()
+        if timestamp_available <= 0:
+            return ""
+        return (
+            datetime.fromtimestamp(timestamp / 1000, tz=timezone.utc)
+            .astimezone()
+            .strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        )
+
+    @staticmethod
+    def _matches(
+        record: Record,
+        *,
+        partition_filter: int | None,
+        key_filter: str | None,
+        value_filter: str | None,
+        header_filter: str | None,
+    ) -> bool:
+        if partition_filter is not None and record.partition != partition_filter:
+            return False
+        if key_filter and key_filter not in record.key_str():
+            return False
+        if value_filter and value_filter not in record.value_str():
+            return False
+        return not header_filter or any(
+            header_filter in header.value_str() for header in record.headers
+        )
 
 
 class ClusterService:
@@ -266,11 +267,11 @@ class EnrichmentResult:
 @dataclass(frozen=True)
 class GroupSnapshot:
     descriptions: tuple[ConsumerGroupDescription, ...] = ()
-    offsets: dict[str, tuple[TopicPartition, ...]] | None = None
+    offsets: dict[str, tuple[TopicPartition, ...]] = field(default_factory=dict)
     errors: tuple[Exception, ...] = ()
 
     def offsets_for(self, group_id: str) -> tuple[TopicPartition, ...]:
-        return (self.offsets or {}).get(group_id, ())
+        return self.offsets.get(group_id, ())
 
 
 class TopicService:
@@ -347,16 +348,26 @@ class TopicService:
 
     async def enrich_offsets(self, topics: dict[str, Topic]) -> EnrichmentResult:
         started_at = perf_counter()
-        partitions = {
-            TopicPartition(topic.name, partition.id): partition
-            for topic in topics.values()
-            for partition in topic.partitions
-        }
+        partitions = self._partition_lookup(topics)
         if not partitions:
-            for topic in topics.values():
-                topic.records_state = MetricState.READY
+            self._set_records_state(topics, MetricState.READY)
             return EnrichmentResult()
 
+        earliest, latest, errors = await self._load_partition_offsets(tuple(partitions))
+        self._apply_partition_offsets(topics, earliest, latest)
+        logger.info(
+            "admin offsets loaded partitions=%d errors=%d elapsed=%.3fs",
+            len(partitions),
+            len(errors),
+            perf_counter() - started_at,
+        )
+        return EnrichmentResult(errors)
+
+    async def _load_partition_offsets(self, partitions: tuple[TopicPartition, ...]) -> tuple[
+        dict[tuple[str, int], int],
+        dict[tuple[str, int], int],
+        tuple[Exception, ...],
+    ]:
         try:
             earliest_futures = self.admin_client.list_offsets(
                 {
@@ -374,17 +385,22 @@ class TopicService:
             )
         except ADMIN_EXCEPTIONS as ex:
             logger.error("admin offset request failed: %s", ex)
-            for topic in topics.values():
-                if topic.records_state is not MetricState.READY:
-                    topic.records_state = MetricState.UNAVAILABLE
-            return EnrichmentResult((ex,))
+            return {}, {}, (ex,)
 
-        earliest_task = asyncio.create_task(self._resolve_offset_futures(earliest_futures))
-        latest_task = asyncio.create_task(self._resolve_offset_futures(latest_futures))
-        earliest, earliest_errors = await earliest_task
-        latest, latest_errors = await latest_task
-        errors = (*earliest_errors, *latest_errors)
+        earliest_result, latest_result = await asyncio.gather(
+            self._resolve_offset_futures(earliest_futures),
+            self._resolve_offset_futures(latest_futures),
+        )
+        earliest, earliest_errors = earliest_result
+        latest, latest_errors = latest_result
+        return earliest, latest, (*earliest_errors, *latest_errors)
 
+    @staticmethod
+    def _apply_partition_offsets(
+        topics: dict[str, Topic],
+        earliest: dict[tuple[str, int], int],
+        latest: dict[tuple[str, int], int],
+    ) -> None:
         for topic in topics.values():
             topic_offsets = [
                 (
@@ -404,13 +420,19 @@ class TopicService:
                         partition.high = high
                 topic.records_state = MetricState.READY
 
-        logger.info(
-            "admin offsets loaded partitions=%d errors=%d elapsed=%.3fs",
-            len(partitions),
-            len(errors),
-            perf_counter() - started_at,
-        )
-        return EnrichmentResult(errors)
+    @staticmethod
+    def _set_records_state(topics: dict[str, Topic], state: MetricState) -> None:
+        for topic in topics.values():
+            if topic.records_state is not MetricState.READY:
+                topic.records_state = state
+
+    @staticmethod
+    def _partition_lookup(topics: dict[str, Topic]) -> dict[TopicPartition, Partition]:
+        return {
+            TopicPartition(topic.name, partition.id): partition
+            for topic in topics.values()
+            for partition in topic.partitions
+        }
 
     async def _resolve_offset_futures(
         self, futures: dict[TopicPartition, Any]
@@ -438,73 +460,89 @@ class TopicService:
 
     async def load_groups(self) -> GroupSnapshot:
         started_at = perf_counter()
-        errors: list[Exception] = []
-        try:
-            list_result = await asyncio.wrap_future(
-                self.admin_client.list_consumer_groups(request_timeout=self.timeout)
-            )
-        except ADMIN_EXCEPTIONS as ex:
-            logger.error("admin consumer-group listing failed: %s", ex)
-            return GroupSnapshot(errors=(ex,))
-
-        errors.extend(list_result.errors or [])
-        group_ids = [group.group_id for group in list_result.valid or []]
+        group_ids, list_errors = await self._list_group_ids()
         if not group_ids:
-            return GroupSnapshot(errors=tuple(errors))
+            return GroupSnapshot(errors=list_errors)
 
-        descriptions: list[ConsumerGroupDescription] = []
-        description_futures = self.admin_client.describe_consumer_groups(
-            group_ids, request_timeout=self.timeout
-        )
-        description_results = await asyncio.gather(
-            *(self._resolve_future(future) for future in description_futures.values())
-        )
-        for description, error in description_results:
-            if error is not None:
-                errors.append(error)
-            elif description is not None:
-                descriptions.append(description)
-
-        semaphore = asyncio.Semaphore(self.GROUP_OFFSET_CONCURRENCY)
-
-        async def load_offsets(
-            group_id: str,
-        ) -> tuple[str, tuple[TopicPartition, ...], Exception | None]:
-            async with semaphore:
-                try:
-                    futures = self.admin_client.list_consumer_group_offsets(
-                        [ConsumerGroupTopicPartitions(group_id)],
-                        request_timeout=self.timeout,
-                    )
-                    result = await asyncio.wrap_future(futures[group_id])
-                    topic_partitions = tuple(result.topic_partitions or ())
-                    partition_errors = [
-                        KafkaException(partition.error)
-                        for partition in topic_partitions
-                        if partition.error is not None
-                    ]
-                    if partition_errors:
-                        return group_id, (), partition_errors[0]
-                    return group_id, topic_partitions, None
-                except ADMIN_EXCEPTIONS as ex:
-                    return group_id, (), ex
-
-        offset_results = await asyncio.gather(*(load_offsets(group_id) for group_id in group_ids))
-        offsets: dict[str, tuple[TopicPartition, ...]] = {}
-        for group_id, topic_partitions, error in offset_results:
-            if error is not None:
-                logger.error("admin consumer-group offsets failed for %s: %s", group_id, error)
-                errors.append(error)
-            else:
-                offsets[group_id] = topic_partitions
-
+        descriptions, description_errors = await self._load_group_descriptions(group_ids)
+        offsets, offset_errors = await self._load_group_offsets(group_ids)
+        errors = (*list_errors, *description_errors, *offset_errors)
         logger.info(
             "admin groups loaded groups=%d errors=%d elapsed=%.3fs",
             len(group_ids),
             len(errors),
             perf_counter() - started_at,
         )
-        return GroupSnapshot(tuple(descriptions), offsets, tuple(errors))
+        return GroupSnapshot(descriptions, offsets, errors)
+
+    async def _list_group_ids(self) -> tuple[tuple[str, ...], tuple[Exception, ...]]:
+        try:
+            list_result = await asyncio.wrap_future(
+                self.admin_client.list_consumer_groups(request_timeout=self.timeout)
+            )
+        except ADMIN_EXCEPTIONS as ex:
+            logger.error("admin consumer-group listing failed: %s", ex)
+            return (), (ex,)
+        return (
+            tuple(group.group_id for group in list_result.valid or []),
+            tuple(list_result.errors or ()),
+        )
+
+    async def _load_group_descriptions(
+        self, group_ids: tuple[str, ...]
+    ) -> tuple[tuple[ConsumerGroupDescription, ...], tuple[Exception, ...]]:
+        descriptions: list[ConsumerGroupDescription] = []
+        description_futures = self.admin_client.describe_consumer_groups(
+            list(group_ids), request_timeout=self.timeout
+        )
+        description_results = await asyncio.gather(
+            *(self._resolve_future(future) for future in description_futures.values())
+        )
+        errors: list[Exception] = []
+        for description, error in description_results:
+            if error is not None:
+                errors.append(error)
+            elif description is not None:
+                descriptions.append(description)
+        return tuple(descriptions), tuple(errors)
+
+    async def _load_group_offsets(
+        self, group_ids: tuple[str, ...]
+    ) -> tuple[dict[str, tuple[TopicPartition, ...]], tuple[Exception, ...]]:
+        semaphore = asyncio.Semaphore(self.GROUP_OFFSET_CONCURRENCY)
+        offset_results = await asyncio.gather(
+            *(self._load_single_group_offsets(group_id, semaphore) for group_id in group_ids)
+        )
+        offsets: dict[str, tuple[TopicPartition, ...]] = {}
+        errors: list[Exception] = []
+        for group_id, topic_partitions, error in offset_results:
+            if error is not None:
+                logger.error("admin consumer-group offsets failed for %s: %s", group_id, error)
+                errors.append(error)
+            else:
+                offsets[group_id] = topic_partitions
+        return offsets, tuple(errors)
+
+    async def _load_single_group_offsets(
+        self, group_id: str, semaphore: asyncio.Semaphore
+    ) -> tuple[str, tuple[TopicPartition, ...], Exception | None]:
+        async with semaphore:
+            try:
+                futures = self.admin_client.list_consumer_group_offsets(
+                    [ConsumerGroupTopicPartitions(group_id)],
+                    request_timeout=self.timeout,
+                )
+                result = await asyncio.wrap_future(futures[group_id])
+                topic_partitions = tuple(result.topic_partitions or ())
+                error = self._first_partition_error(topic_partitions)
+                return group_id, () if error else topic_partitions, error
+            except ADMIN_EXCEPTIONS as ex:
+                return group_id, (), ex
+
+    @staticmethod
+    def _first_partition_error(partitions: tuple[TopicPartition, ...]) -> Exception | None:
+        partition = next((item for item in partitions if item.error is not None), None)
+        return KafkaException(partition.error) if partition is not None else None
 
     async def _resolve_future(self, future: Any) -> tuple[Any | None, Exception | None]:
         try:
@@ -515,11 +553,29 @@ class TopicService:
 
     def apply_groups(self, topics: dict[str, Topic], snapshot: GroupSnapshot) -> EnrichmentResult:
         if snapshot.errors:
-            for topic in topics.values():
-                if topic.groups_state is not MetricState.READY:
-                    topic.groups_state = MetricState.UNAVAILABLE
+            self._set_groups_unavailable(topics)
             return EnrichmentResult(snapshot.errors)
 
+        self._reset_groups(topics)
+        partitions = self._partitions_by_key(topics)
+
+        for group_metadata in snapshot.descriptions:
+            committed_by_topic = self._committed_by_topic(group_metadata, snapshot, topics)
+            for topic_name, committed in committed_by_topic.items():
+                group = self._map_group(group_metadata, topic_name, committed, partitions)
+                if group.partitions:
+                    topics[topic_name].groups.append(group)
+
+        return EnrichmentResult()
+
+    @staticmethod
+    def _set_groups_unavailable(topics: dict[str, Topic]) -> None:
+        for topic in topics.values():
+            if topic.groups_state is not MetricState.READY:
+                topic.groups_state = MetricState.UNAVAILABLE
+
+    @staticmethod
+    def _reset_groups(topics: dict[str, Topic]) -> None:
         for topic in topics.values():
             topic.groups = []
             topic.groups_state = (
@@ -528,77 +584,101 @@ class TopicService:
                 else MetricState.UNAVAILABLE
             )
 
-        partitions = {
+    @staticmethod
+    def _partitions_by_key(topics: dict[str, Topic]) -> dict[tuple[str, int], Partition]:
+        return {
             (topic.name, partition.id): partition
             for topic in topics.values()
             for partition in topic.partitions
         }
 
-        for group_metadata in snapshot.descriptions:
-            committed_by_topic: dict[str, list[TopicPartition]] = {}
-            for committed in snapshot.offsets_for(group_metadata.group_id):
-                if committed.offset == OFFSET_INVALID or committed.topic not in topics:
-                    continue
-                committed_by_topic.setdefault(str(committed.topic), []).append(committed)
+    @staticmethod
+    def _committed_by_topic(
+        group_metadata: ConsumerGroupDescription,
+        snapshot: GroupSnapshot,
+        topics: dict[str, Topic],
+    ) -> dict[str, list[TopicPartition]]:
+        committed_by_topic: dict[str, list[TopicPartition]] = {}
+        for committed in snapshot.offsets_for(group_metadata.group_id):
+            topic_name = str(committed.topic)
+            if committed.offset == OFFSET_INVALID or topic_name not in topics:
+                continue
+            committed_by_topic.setdefault(topic_name, []).append(committed)
+        return committed_by_topic
 
-            for topic_name, committed_partitions in committed_by_topic.items():
-                topic = topics[topic_name]
-                coordinator = group_metadata.coordinator
-                group = Group(
-                    id=group_metadata.group_id,
-                    partition_assignor=group_metadata.partition_assignor,
-                    state=str(getattr(group_metadata.state, "name", group_metadata.state)).lower(),
-                    coordinator=(
-                        Node(
-                            id=coordinator.id,
-                            host=coordinator.host,
-                            port=coordinator.port,
-                            rack=coordinator.rack,
-                        )
-                        if coordinator is not None
-                        else None
-                    ),
-                )
+    def _map_group(
+        self,
+        metadata: ConsumerGroupDescription,
+        topic_name: str,
+        committed_partitions: list[TopicPartition],
+        partitions: dict[tuple[str, int], Partition],
+    ) -> Group:
+        group = Group(
+            id=metadata.group_id,
+            partition_assignor=metadata.partition_assignor,
+            state=str(getattr(metadata.state, "name", metadata.state)).lower(),
+            coordinator=self._map_coordinator(metadata.coordinator),
+        )
+        group.partitions = self._map_group_partitions(
+            metadata.group_id, topic_name, committed_partitions, partitions
+        )
+        group.members = self._map_group_members(metadata, topic_name)
+        return group
 
-                for committed in committed_partitions:
-                    partition = partitions.get((topic_name, committed.partition))
-                    if partition is None:
-                        continue
-                    group.partitions.append(
-                        GroupPartition(
-                            id=committed.partition,
-                            topic=topic_name,
-                            offset=committed.offset,
-                            group=group_metadata.group_id,
-                            high=partition.high,
-                            low=partition.low,
-                        )
+    @staticmethod
+    def _map_coordinator(coordinator: Any) -> Node | None:
+        if coordinator is None:
+            return None
+        return Node(
+            id=coordinator.id,
+            host=coordinator.host,
+            port=coordinator.port,
+            rack=coordinator.rack,
+        )
+
+    @staticmethod
+    def _map_group_partitions(
+        group_id: str,
+        topic_name: str,
+        committed_partitions: list[TopicPartition],
+        partitions: dict[tuple[str, int], Partition],
+    ) -> list[GroupPartition]:
+        return [
+            GroupPartition(
+                id=committed.partition,
+                topic=topic_name,
+                offset=committed.offset,
+                group=group_id,
+                high=partition.high,
+                low=partition.low,
+            )
+            for committed in committed_partitions
+            if (partition := partitions.get((topic_name, committed.partition))) is not None
+        ]
+
+    @staticmethod
+    def _map_group_members(
+        metadata: ConsumerGroupDescription, topic_name: str
+    ) -> list[GroupMember]:
+        members: list[GroupMember] = []
+        for member in metadata.members:
+            assignments = [
+                assigned.partition
+                for assigned in member.assignment.topic_partitions
+                if assigned.topic == topic_name
+            ]
+            if assignments:
+                members.append(
+                    GroupMember(
+                        id=member.member_id,
+                        group=metadata.group_id,
+                        client_id=member.client_id,
+                        host=member.host,
+                        instance_id=member.group_instance_id,
+                        assignment=assignments,
                     )
-
-                if not group.partitions:
-                    continue
-
-                for member_metadata in group_metadata.members:
-                    member_partitions = [
-                        assigned.partition
-                        for assigned in member_metadata.assignment.topic_partitions
-                        if assigned.topic == topic_name
-                    ]
-                    if member_partitions:
-                        group.members.append(
-                            GroupMember(
-                                id=member_metadata.member_id,
-                                group=group_metadata.group_id,
-                                client_id=member_metadata.client_id,
-                                host=member_metadata.host,
-                                instance_id=member_metadata.group_instance_id,
-                                assignment=member_partitions,
-                            )
-                        )
-
-                topic.groups.append(group)
-
-        return EnrichmentResult()
+                )
+        return members
 
     def _map_topics(self, topics_metadata: list[TopicMetadata]) -> dict[str, Topic]:
         topics: dict[str, Topic] = {}

--- a/kaskade/services.py
+++ b/kaskade/services.py
@@ -180,7 +180,7 @@ class ConsumerService:
             date=self._message_date(message),
             headers=[
                 Header(key=key, value=value, value_deserializer=self.header_deserializer)
-                for key, value in (message.headers() or [])
+                for key, value in message.headers() or []
             ],
             key_deserialization=self.key_deserialization,
             value_deserialization=self.value_deserialization,

--- a/kaskade/services.py
+++ b/kaskade/services.py
@@ -1,8 +1,17 @@
+import asyncio
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from time import perf_counter
 from typing import Any
 
-from confluent_kafka import OFFSET_INVALID, Consumer, KafkaException, TopicPartition
+from confluent_kafka import (
+    OFFSET_INVALID,
+    Consumer,
+    ConsumerGroupTopicPartitions,
+    KafkaException,
+    TopicPartition,
+)
 from confluent_kafka.admin import (
     AdminClient,
     AlterConfigOpType,
@@ -11,7 +20,7 @@ from confluent_kafka.admin import (
     ConfigSource,
     ConsumerGroupDescription,
     DescribeClusterResult,
-    PartitionMetadata,
+    OffsetSpec,
     ResourceType,
     TopicMetadata,
 )
@@ -26,12 +35,20 @@ from kaskade.models import (
     GroupMember,
     GroupPartition,
     Header,
+    MetricState,
     Node,
     Partition,
     Record,
     Topic,
 )
 from kaskade.utils import make_it_async
+
+ADMIN_EXCEPTIONS: tuple[type[Exception], ...] = (
+    KafkaException,
+    RuntimeError,
+    TypeError,
+    ValueError,
+)
 
 
 class ConsumerService:
@@ -56,6 +73,8 @@ class ConsumerService:
         self.key_deserialization = key_deserialization
         self.value_deserialization = value_deserialization
         self.stable = False
+        self.started_at = perf_counter()
+        self.assigned_at: float | None = None
         self.consumer = Consumer(
             kafka_config
             | {
@@ -70,6 +89,13 @@ class ConsumerService:
 
     def on_assign(self, consumer: Consumer, partitions: list[TopicPartition]) -> None:
         self.stable = True
+        self.assigned_at = perf_counter()
+        logger.info(
+            "consumer assigned topic=%s partitions=%d elapsed=%.3fs",
+            self.topic,
+            len(partitions),
+            self.assigned_at - self.started_at,
+        )
 
     def close(self) -> None:
         self.consumer.unsubscribe()
@@ -83,9 +109,12 @@ class ConsumerService:
         value_filter: str | None = None,
         header_filter: str | None = None,
     ) -> list[Record]:
+        chunk_started_at = perf_counter()
         records: list[Record] = []
         poll_retries = 0
         stabilization_retries = 0
+        scanned_records = 0
+        first_record_at: float | None = None
 
         while len(records) < self.page_size:
             if poll_retries >= self.poll_retries:
@@ -94,74 +123,97 @@ class ConsumerService:
             if stabilization_retries >= self.stabilization_retries:
                 break
 
-            record_metadata = await make_it_async(self.consumer.poll, self.timeout)
+            record_batch = await make_it_async(
+                self.consumer.consume,
+                self.page_size - len(records),
+                timeout=self.timeout,
+            )
 
             if not self.stable:
                 stabilization_retries += 1
                 continue
             stabilization_retries = 0
 
-            if record_metadata is None:
+            if not record_batch:
                 poll_retries += 1
                 continue
             poll_retries = 0
 
-            if record_metadata.error():
-                raise KafkaException(record_metadata.error())
+            for record_metadata in record_batch:
+                if record_metadata.error():
+                    raise KafkaException(record_metadata.error())
 
-            timestamp_available, timestamp = record_metadata.timestamp()
-            date = (
-                datetime.fromtimestamp(timestamp / 1000, tz=timezone.utc)
-                .astimezone()
-                .strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
-                if timestamp_available > 0
-                else ""
-            )
+                scanned_records += 1
+                if first_record_at is None:
+                    first_record_at = perf_counter()
 
-            record = Record(
-                topic=self.topic,
-                partition=record_metadata.partition(),
-                offset=record_metadata.offset(),
-                key=record_metadata.key(),
-                value=record_metadata.value(),
-                date=date,
-                headers=(
-                    [
-                        Header(
-                            key=key,
-                            value=value,
-                            value_deserializer=self.deserializer_factory.get(
-                                Deserialization.STRING
-                            ),
-                        )
-                        for key, value in record_metadata.headers()
-                    ]
-                    if record_metadata.headers() is not None
-                    else []
-                ),
-                key_deserialization=self.key_deserialization,
-                value_deserialization=self.value_deserialization,
-                key_deserializer=self.deserializer_factory.get(self.key_deserialization),
-                value_deserializer=self.deserializer_factory.get(self.value_deserialization),
-            )
+                timestamp_available, timestamp = record_metadata.timestamp()
+                date = (
+                    datetime.fromtimestamp(timestamp / 1000, tz=timezone.utc)
+                    .astimezone()
+                    .strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+                    if timestamp_available > 0
+                    else ""
+                )
 
-            if partition_filter is not None and record.partition != partition_filter:
-                continue
+                record = Record(
+                    topic=self.topic,
+                    partition=record_metadata.partition(),
+                    offset=record_metadata.offset(),
+                    key=record_metadata.key(),
+                    value=record_metadata.value(),
+                    date=date,
+                    headers=(
+                        [
+                            Header(
+                                key=key,
+                                value=value,
+                                value_deserializer=self.deserializer_factory.get(
+                                    Deserialization.STRING
+                                ),
+                            )
+                            for key, value in record_metadata.headers()
+                        ]
+                        if record_metadata.headers() is not None
+                        else []
+                    ),
+                    key_deserialization=self.key_deserialization,
+                    value_deserialization=self.value_deserialization,
+                    key_deserializer=self.deserializer_factory.get(self.key_deserialization),
+                    value_deserializer=self.deserializer_factory.get(self.value_deserialization),
+                )
 
-            if key_filter and key_filter not in record.key_str():
-                continue
-
-            if value_filter and value_filter not in record.value_str():
-                continue
-
-            if header_filter:
-                if record.headers is None:
+                if partition_filter is not None and record.partition != partition_filter:
                     continue
 
-                if not [header for header in record.headers if header_filter in header.value_str()]:
+                if key_filter and key_filter not in record.key_str():
                     continue
 
-            records.append(record)
+                if value_filter and value_filter not in record.value_str():
+                    continue
+
+                if header_filter:
+                    if record.headers is None:
+                        continue
+
+                    if not [
+                        header for header in record.headers if header_filter in header.value_str()
+                    ]:
+                        continue
+
+                records.append(record)
+                if len(records) >= self.page_size:
+                    break
+
+        logger.info(
+            "consumer chunk completed topic=%s scanned=%d matched=%d first_record=%.3fs "
+            "elapsed=%.3fs",
+            self.topic,
+            scanned_records,
+            len(records),
+            first_record_at - chunk_started_at if first_record_at is not None else -1,
+            perf_counter() - chunk_started_at,
+        )
 
         return records
 
@@ -202,7 +254,28 @@ class ClusterService:
         )
 
 
+@dataclass(frozen=True)
+class EnrichmentResult:
+    errors: tuple[Exception, ...] = ()
+
+    @property
+    def successful(self) -> bool:
+        return not self.errors
+
+
+@dataclass(frozen=True)
+class GroupSnapshot:
+    descriptions: tuple[ConsumerGroupDescription, ...] = ()
+    offsets: dict[str, tuple[TopicPartition, ...]] | None = None
+    errors: tuple[Exception, ...] = ()
+
+    def offsets_for(self, group_id: str) -> tuple[TopicPartition, ...]:
+        return (self.offsets or {}).get(group_id, ())
+
+
 class TopicService:
+    GROUP_OFFSET_CONCURRENCY = 16
+
     def __init__(
         self, config: dict[str, str | int | float | bool], *, timeout: float = 2.0
     ) -> None:
@@ -253,79 +326,267 @@ class TopicService:
             future.result()
 
     async def all(self) -> dict[str, Topic]:
-        topics = await self._map_topics(self._list_topics_metadata())
-        await self._map_groups_into_topics(self._list_groups_metadata(), topics)
+        topics = await self.metadata()
+        offsets_task = asyncio.create_task(self.enrich_offsets(topics))
+        groups_task = asyncio.create_task(self.load_groups())
+        await offsets_task
+        self.apply_groups(topics, await groups_task)
         return topics
 
-    async def _map_groups_into_topics(
-        self, groups_metadata: list[ConsumerGroupDescription], topics: dict[str, Topic]
-    ) -> None:
-        for group_metadata in groups_metadata:
-            group_consumer = Consumer(self.config | {GROUP_ID: group_metadata.group_id})
+    async def metadata(self) -> dict[str, Topic]:
+        started_at = perf_counter()
+        topics_metadata = await make_it_async(self._list_topics_metadata)
+        topics = self._map_topics(topics_metadata)
+        logger.info(
+            "admin metadata loaded topics=%d partitions=%d elapsed=%.3fs",
+            len(topics),
+            sum(topic.partitions_count() for topic in topics.values()),
+            perf_counter() - started_at,
+        )
+        return topics
+
+    async def enrich_offsets(self, topics: dict[str, Topic]) -> EnrichmentResult:
+        started_at = perf_counter()
+        partitions = {
+            TopicPartition(topic.name, partition.id): partition
+            for topic in topics.values()
+            for partition in topic.partitions
+        }
+        if not partitions:
             for topic in topics.values():
+                topic.records_state = MetricState.READY
+            return EnrichmentResult()
 
-                coordinator = Node(
-                    id=group_metadata.coordinator.id,
-                    host=group_metadata.coordinator.host,
-                    port=group_metadata.coordinator.port,
-                    rack=group_metadata.coordinator.rack,
+        try:
+            earliest_futures = self.admin_client.list_offsets(
+                {
+                    topic_partition: OffsetSpec.earliest()  # type: ignore[no-untyped-call]
+                    for topic_partition in partitions
+                },
+                request_timeout=self.timeout,
+            )
+            latest_futures = self.admin_client.list_offsets(
+                {
+                    topic_partition: OffsetSpec.latest()  # type: ignore[no-untyped-call]
+                    for topic_partition in partitions
+                },
+                request_timeout=self.timeout,
+            )
+        except ADMIN_EXCEPTIONS as ex:
+            logger.error("admin offset request failed: %s", ex)
+            for topic in topics.values():
+                if topic.records_state is not MetricState.READY:
+                    topic.records_state = MetricState.UNAVAILABLE
+            return EnrichmentResult((ex,))
+
+        earliest_task = asyncio.create_task(self._resolve_offset_futures(earliest_futures))
+        latest_task = asyncio.create_task(self._resolve_offset_futures(latest_futures))
+        earliest, earliest_errors = await earliest_task
+        latest, latest_errors = await latest_task
+        errors = (*earliest_errors, *latest_errors)
+
+        for topic in topics.values():
+            topic_offsets = [
+                (
+                    partition,
+                    earliest.get((topic.name, partition.id)),
+                    latest.get((topic.name, partition.id)),
                 )
+                for partition in topic.partitions
+            ]
+            if any(low is None or high is None for _, low, high in topic_offsets):
+                if topic.records_state is not MetricState.READY:
+                    topic.records_state = MetricState.UNAVAILABLE
+            else:
+                for partition, low, high in topic_offsets:
+                    if low is not None and high is not None:
+                        partition.low = low
+                        partition.high = high
+                topic.records_state = MetricState.READY
 
+        logger.info(
+            "admin offsets loaded partitions=%d errors=%d elapsed=%.3fs",
+            len(partitions),
+            len(errors),
+            perf_counter() - started_at,
+        )
+        return EnrichmentResult(errors)
+
+    async def _resolve_offset_futures(
+        self, futures: dict[TopicPartition, Any]
+    ) -> tuple[dict[tuple[str, int], int], tuple[Exception, ...]]:
+        async def resolve(
+            topic_partition: TopicPartition, future: Any
+        ) -> tuple[TopicPartition, int | None, Exception | None]:
+            try:
+                result = await asyncio.wrap_future(future)
+                return topic_partition, result.offset, None
+            except ADMIN_EXCEPTIONS as ex:
+                logger.error("admin partition offset failed for %s: %s", topic_partition, ex)
+                return topic_partition, None, ex
+
+        resolved = await asyncio.gather(
+            *(resolve(topic_partition, future) for topic_partition, future in futures.items())
+        )
+        offsets = {
+            (str(topic_partition.topic), topic_partition.partition): offset
+            for topic_partition, offset, error in resolved
+            if error is None and offset is not None
+        }
+        errors = tuple(error for _, _, error in resolved if error is not None)
+        return offsets, errors
+
+    async def load_groups(self) -> GroupSnapshot:
+        started_at = perf_counter()
+        errors: list[Exception] = []
+        try:
+            list_result = await asyncio.wrap_future(
+                self.admin_client.list_consumer_groups(request_timeout=self.timeout)
+            )
+        except ADMIN_EXCEPTIONS as ex:
+            logger.error("admin consumer-group listing failed: %s", ex)
+            return GroupSnapshot(errors=(ex,))
+
+        errors.extend(list_result.errors or [])
+        group_ids = [group.group_id for group in list_result.valid or []]
+        if not group_ids:
+            return GroupSnapshot(errors=tuple(errors))
+
+        descriptions: list[ConsumerGroupDescription] = []
+        description_futures = self.admin_client.describe_consumer_groups(
+            group_ids, request_timeout=self.timeout
+        )
+        description_results = await asyncio.gather(
+            *(self._resolve_future(future) for future in description_futures.values())
+        )
+        for description, error in description_results:
+            if error is not None:
+                errors.append(error)
+            elif description is not None:
+                descriptions.append(description)
+
+        semaphore = asyncio.Semaphore(self.GROUP_OFFSET_CONCURRENCY)
+
+        async def load_offsets(
+            group_id: str,
+        ) -> tuple[str, tuple[TopicPartition, ...], Exception | None]:
+            async with semaphore:
+                try:
+                    futures = self.admin_client.list_consumer_group_offsets(
+                        [ConsumerGroupTopicPartitions(group_id)],
+                        request_timeout=self.timeout,
+                    )
+                    result = await asyncio.wrap_future(futures[group_id])
+                    topic_partitions = tuple(result.topic_partitions or ())
+                    partition_errors = [
+                        KafkaException(partition.error)
+                        for partition in topic_partitions
+                        if partition.error is not None
+                    ]
+                    if partition_errors:
+                        return group_id, (), partition_errors[0]
+                    return group_id, topic_partitions, None
+                except ADMIN_EXCEPTIONS as ex:
+                    return group_id, (), ex
+
+        offset_results = await asyncio.gather(*(load_offsets(group_id) for group_id in group_ids))
+        offsets: dict[str, tuple[TopicPartition, ...]] = {}
+        for group_id, topic_partitions, error in offset_results:
+            if error is not None:
+                logger.error("admin consumer-group offsets failed for %s: %s", group_id, error)
+                errors.append(error)
+            else:
+                offsets[group_id] = topic_partitions
+
+        logger.info(
+            "admin groups loaded groups=%d errors=%d elapsed=%.3fs",
+            len(group_ids),
+            len(errors),
+            perf_counter() - started_at,
+        )
+        return GroupSnapshot(tuple(descriptions), offsets, tuple(errors))
+
+    async def _resolve_future(self, future: Any) -> tuple[Any | None, Exception | None]:
+        try:
+            return await asyncio.wrap_future(future), None
+        except ADMIN_EXCEPTIONS as ex:
+            logger.error("admin request failed: %s", ex)
+            return None, ex
+
+    def apply_groups(self, topics: dict[str, Topic], snapshot: GroupSnapshot) -> EnrichmentResult:
+        if snapshot.errors:
+            for topic in topics.values():
+                if topic.groups_state is not MetricState.READY:
+                    topic.groups_state = MetricState.UNAVAILABLE
+            return EnrichmentResult(snapshot.errors)
+
+        for topic in topics.values():
+            topic.groups = []
+            topic.groups_state = (
+                MetricState.READY
+                if topic.records_state is MetricState.READY
+                else MetricState.UNAVAILABLE
+            )
+
+        partitions = {
+            (topic.name, partition.id): partition
+            for topic in topics.values()
+            for partition in topic.partitions
+        }
+
+        for group_metadata in snapshot.descriptions:
+            committed_by_topic: dict[str, list[TopicPartition]] = {}
+            for committed in snapshot.offsets_for(group_metadata.group_id):
+                if committed.offset == OFFSET_INVALID or committed.topic not in topics:
+                    continue
+                committed_by_topic.setdefault(str(committed.topic), []).append(committed)
+
+            for topic_name, committed_partitions in committed_by_topic.items():
+                topic = topics[topic_name]
+                coordinator = group_metadata.coordinator
                 group = Group(
                     id=group_metadata.group_id,
                     partition_assignor=group_metadata.partition_assignor,
-                    state=str(group_metadata.state.name.lower()),
-                    coordinator=coordinator,
-                )
-
-                topic_partitions_for_this_group_metadata = [
-                    TopicPartition(topic.name, partition.id) for partition in topic.partitions
-                ]
-
-                committed_partitions_metadata = await make_it_async(
-                    group_consumer.committed,
-                    topic_partitions_for_this_group_metadata,
-                    timeout=self.timeout,
-                )
-
-                for group_partition_metadata in committed_partitions_metadata:
-                    if group_partition_metadata.offset == OFFSET_INVALID:
-                        continue
-
-                    low_group_partition_watermark, high_group_partition_watermark = 0, 0
-
-                    try:
-                        low_group_partition_watermark, high_group_partition_watermark = (
-                            await make_it_async(
-                                group_consumer.get_watermark_offsets,
-                                group_partition_metadata,
-                                timeout=self.timeout,
-                                cached=False,
-                            )
+                    state=str(getattr(group_metadata.state, "name", group_metadata.state)).lower(),
+                    coordinator=(
+                        Node(
+                            id=coordinator.id,
+                            host=coordinator.host,
+                            port=coordinator.port,
+                            rack=coordinator.rack,
                         )
-                    except KafkaException as ex:
-                        logger.exception(ex)
+                        if coordinator is not None
+                        else None
+                    ),
+                )
 
-                    group_partition = GroupPartition(
-                        id=group_partition_metadata.partition,
-                        topic=group_partition_metadata.topic,
-                        offset=group_partition_metadata.offset,
-                        group=group_metadata.group_id,
-                        high=high_group_partition_watermark,
-                        low=low_group_partition_watermark,
+                for committed in committed_partitions:
+                    partition = partitions.get((topic_name, committed.partition))
+                    if partition is None:
+                        continue
+                    group.partitions.append(
+                        GroupPartition(
+                            id=committed.partition,
+                            topic=topic_name,
+                            offset=committed.offset,
+                            group=group_metadata.group_id,
+                            high=partition.high,
+                            low=partition.low,
+                        )
                     )
 
-                    group.partitions.append(group_partition)
+                if not group.partitions:
+                    continue
 
-                if len(group.partitions) > 0:
-                    for member_metadata in group_metadata.members:
-                        member_partitions = [
-                            topic_partition.partition
-                            for topic_partition in member_metadata.assignment.topic_partitions
-                            if topic.name == topic_partition.topic
-                        ]
-                        if len(member_partitions) > 0:
-                            member = GroupMember(
+                for member_metadata in group_metadata.members:
+                    member_partitions = [
+                        assigned.partition
+                        for assigned in member_metadata.assignment.topic_partitions
+                        if assigned.topic == topic_name
+                    ]
+                    if member_partitions:
+                        group.members.append(
+                            GroupMember(
                                 id=member_metadata.member_id,
                                 group=group_metadata.group_id,
                                 client_id=member_metadata.client_id,
@@ -333,72 +594,29 @@ class TopicService:
                                 instance_id=member_metadata.group_instance_id,
                                 assignment=member_partitions,
                             )
-                            group.members.append(member)
+                        )
 
-                    topic.groups.append(group)
+                topic.groups.append(group)
 
-    async def _map_topics(self, topics_metadata: list[TopicMetadata]) -> dict[str, Topic]:
-        topics = {}
+        return EnrichmentResult()
 
+    def _map_topics(self, topics_metadata: list[TopicMetadata]) -> dict[str, Topic]:
+        topics: dict[str, Topic] = {}
         for topic_metadata in topics_metadata:
-            topic = Topic(name=str(topic_metadata.topic))
-            topics[str(topic_metadata.topic)] = topic
-
-            for topic_partition_metadata in topic_metadata.partitions.values():
-                low_topic_partition_watermark, high_topic_partition_watermark = (
-                    await self._get_watermarks(topic_metadata, topic_partition_metadata)
+            topic_name = str(topic_metadata.topic)
+            topic = Topic(name=topic_name)
+            topics[topic_name] = topic
+            for partition_metadata in topic_metadata.partitions.values():
+                topic.partitions.append(
+                    Partition(
+                        id=partition_metadata.id,
+                        topic=topic_name,
+                        leader=partition_metadata.leader,
+                        replicas=partition_metadata.replicas,
+                        isrs=partition_metadata.isrs,
+                    )
                 )
-
-                partition = Partition(
-                    id=topic_partition_metadata.id,
-                    topic=str(topic_metadata.topic),
-                    leader=topic_partition_metadata.leader,
-                    replicas=topic_partition_metadata.replicas,
-                    isrs=topic_partition_metadata.isrs,
-                    high=high_topic_partition_watermark,
-                    low=low_topic_partition_watermark,
-                )
-
-                topic.partitions.append(partition)
-
         return topics
-
-    async def _get_watermarks(
-        self, topic_metadata: TopicMetadata, partition_metadata: PartitionMetadata
-    ) -> tuple[int, int]:
-        low, high = 0, 0
-
-        consumer = Consumer(self.config | {GROUP_ID: f"kaskade-{uuid.uuid4()}"})
-
-        try:
-            low, high = await make_it_async(
-                consumer.get_watermark_offsets,
-                TopicPartition(str(topic_metadata.topic), partition_metadata.id),
-                timeout=self.timeout,
-                cached=False,
-            )
-        except KafkaException as ex:
-            logger.exception(ex)
-
-        return low, high
-
-    def _list_groups_metadata(self) -> list[ConsumerGroupDescription]:
-        group_names: list[str] = [
-            group.group_id
-            for group in (
-                self.admin_client.list_consumer_groups(request_timeout=self.timeout).result().valid
-            )
-        ]
-
-        if not group_names:
-            return []
-
-        return [
-            future.result()
-            for group_id, future in self.admin_client.describe_consumer_groups(
-                group_names, request_timeout=self.timeout
-            ).items()
-        ]
 
     def _list_topics_metadata(self) -> list[TopicMetadata]:
         def sort_by_topic_name(topic: TopicMetadata) -> Any:

--- a/kaskade/themes.py
+++ b/kaskade/themes.py
@@ -10,7 +10,7 @@ from textual.screen import Screen
 from textual.theme import BUILTIN_THEMES, Theme
 
 from kaskade.help import HelpScreen, contextual_help
-from kaskade.keymaps import NAVIGATION_BINDING_IDS, load_keymap
+from kaskade.keymaps import NAVIGATION_BINDING_IDS, load_settings
 
 DEFAULT_THEME = "eva01"
 KASKADE_COMMAND_ID_PREFIX = "kaskade."
@@ -85,7 +85,7 @@ class KaskadeApp(App, inherit_bindings=False):
     def __init__(self, *, keymap_path: Path | None = None) -> None:
         self._rich_theme_pushed = False
         super().__init__()
-        self.keymap_settings = load_keymap(keymap_path)
+        self.keymap_settings = load_settings(keymap_path)
         self.set_keymap(self.keymap_settings.keymap)
         self.register_theme(EVA01_THEME)
         self.theme = DEFAULT_THEME

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,12 @@ line-length = 100
 [tool.ruff]
 line-length = 100
 
+[tool.ruff.lint]
+extend-select = ["C901"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
 [tool.typos]
 type.lock.extend-glob = ["*.lock"]
 type.lock.check-file = true

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,18 @@
+from unittest.mock import AsyncMock, MagicMock
+
 from faker import Faker
 
+from kaskade.models import MetricState, Topic
+from kaskade.services import EnrichmentResult, GroupSnapshot
+
 faker = Faker()
+
+
+def configure_admin_service(service: MagicMock, topics: dict[str, Topic]) -> None:
+    for topic in topics.values():
+        topic.records_state = MetricState.READY
+        topic.groups_state = MetricState.READY
+    service.metadata = AsyncMock(return_value=topics)
+    service.enrich_offsets = AsyncMock(return_value=EnrichmentResult())
+    service.load_groups = AsyncMock(return_value=GroupSnapshot())
+    service.apply_groups.return_value = EnrichmentResult()

--- a/tests/tests_admin.py
+++ b/tests/tests_admin.py
@@ -9,11 +9,56 @@ from confluent_kafka import KafkaException
 from confluent_kafka.cimpl import NewTopic
 from textual.widgets import DataTable, Input
 
-from kaskade.admin import CreateTopicScreen, FilterTopicsScreen, KaskadeAdmin, ListTopics
+from kaskade.admin import (
+    CreateTopicScreen,
+    FilterTopicsScreen,
+    KaskadeAdmin,
+    ListTopics,
+    RefreshCoordinator,
+    RefreshReason,
+)
 from kaskade.keymaps import CONFIG_ENV_VAR
 from kaskade.models import MetricState, Partition, Topic
 from kaskade.services import EnrichmentResult, GroupSnapshot
 from tests import configure_admin_service
+
+
+class TestRefreshCoordinator(unittest.TestCase):
+    def test_coalesces_non_periodic_requests(self) -> None:
+        coordinator = RefreshCoordinator()
+
+        generation = coordinator.request(RefreshReason.INITIAL)
+
+        self.assertEqual(1, generation)
+        self.assertIsNone(coordinator.request(RefreshReason.MANUAL))
+        self.assertIsNone(coordinator.request(RefreshReason.RESUME))
+        self.assertTrue(coordinator.pending)
+        self.assertTrue(coordinator.complete(1))
+        self.assertTrue(coordinator.take_pending())
+        self.assertFalse(coordinator.take_pending())
+
+    def test_skips_periodic_requests_during_active_work(self) -> None:
+        coordinator = RefreshCoordinator()
+        coordinator.request(RefreshReason.INITIAL)
+
+        self.assertIsNone(coordinator.request(RefreshReason.PERIODIC))
+        self.assertFalse(coordinator.pending)
+
+    def test_queues_requests_during_mutation(self) -> None:
+        coordinator = RefreshCoordinator()
+        coordinator.begin_mutation()
+
+        self.assertIsNone(coordinator.request(RefreshReason.MANUAL))
+        self.assertTrue(coordinator.pending)
+        coordinator.end_mutation()
+        self.assertTrue(coordinator.take_pending())
+
+    def test_rejects_stale_completion(self) -> None:
+        coordinator = RefreshCoordinator()
+        generation = coordinator.request(RefreshReason.INITIAL)
+
+        self.assertFalse(coordinator.complete(0))
+        self.assertTrue(coordinator.is_current(generation or 0))
 
 
 class TestCreateTopic(unittest.IsolatedAsyncioTestCase):
@@ -69,6 +114,18 @@ class TestCreateTopic(unittest.IsolatedAsyncioTestCase):
 
 
 class TestAdminRefresh(unittest.IsolatedAsyncioTestCase):
+    async def test_cancels_and_awaits_pending_stage_tasks(self) -> None:
+        gate = asyncio.Event()
+
+        async def wait_forever() -> None:
+            await gate.wait()
+
+        tasks = [asyncio.create_task(wait_forever()), asyncio.create_task(wait_forever())]
+
+        await ListTopics._cancel_stage_tasks(tasks)
+
+        self.assertTrue(all(task.done() and task.cancelled() for task in tasks))
+
     async def test_command_line_interval_overrides_config(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             config_path = Path(temporary_directory) / "config.yaml"
@@ -172,3 +229,134 @@ class TestAdminRefresh(unittest.IsolatedAsyncioTestCase):
                 await asyncio.sleep(0.2)
                 await pilot.pause()
                 self.assertEqual(1, service.metadata.call_count)
+
+    async def test_manual_refreshes_coalesce_without_overlapping(self) -> None:
+        first_refresh_gate = asyncio.Event()
+        active_calls = 0
+        max_active_calls = 0
+        service = MagicMock()
+
+        async def metadata() -> dict[str, Topic]:
+            nonlocal active_calls, max_active_calls
+            active_calls += 1
+            max_active_calls = max(max_active_calls, active_calls)
+            if service.metadata.call_count == 1:
+                await first_refresh_gate.wait()
+            active_calls -= 1
+            return {}
+
+        service.metadata.side_effect = metadata
+        service.enrich_offsets = AsyncMock(return_value=EnrichmentResult())
+        service.load_groups = AsyncMock(return_value=GroupSnapshot())
+        service.apply_groups.return_value = EnrichmentResult()
+
+        with patch("kaskade.admin.TopicService", return_value=service):
+            app = KaskadeAdmin({})
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                topics = app.query_one(ListTopics)
+                topics.request_refresh(RefreshReason.MANUAL)
+                topics.request_refresh(RefreshReason.MANUAL)
+
+                self.assertEqual(1, service.metadata.call_count)
+                first_refresh_gate.set()
+                await app.workers.wait_for_complete()
+                await pilot.pause()
+                await app.workers.wait_for_complete()
+
+                self.assertEqual(2, service.metadata.call_count)
+                self.assertEqual(1, max_active_calls)
+
+    async def test_consolidates_partial_stage_failures(self) -> None:
+        topic = Topic(name="orders", partitions=[Partition(id=0)])
+        service = MagicMock()
+        service.metadata = AsyncMock(return_value={"orders": topic})
+        service.enrich_offsets = AsyncMock(
+            return_value=EnrichmentResult((RuntimeError("offsets"),))
+        )
+        service.load_groups = AsyncMock(
+            return_value=GroupSnapshot(errors=(RuntimeError("groups"),))
+        )
+        service.apply_groups.return_value = EnrichmentResult((RuntimeError("groups"),))
+
+        with patch("kaskade.admin.TopicService", return_value=service):
+            app = KaskadeAdmin({})
+            with patch.object(app, "notify") as notify:
+                async with app.run_test():
+                    await app.workers.wait_for_complete()
+
+            partial_notifications = [
+                call
+                for call in notify.call_args_list
+                if call.kwargs.get("title") == "Partial Refresh"
+            ]
+            self.assertEqual(1, len(partial_notifications))
+            message = partial_notifications[0].args[0]
+            self.assertIn("record metrics", message)
+            self.assertIn("consumer-group metrics", message)
+
+    async def test_metadata_failure_keeps_previous_snapshot(self) -> None:
+        topic = Topic(
+            name="orders",
+            partitions=[Partition(id=0, high=10)],
+            records_state=MetricState.READY,
+            groups_state=MetricState.READY,
+        )
+        service = MagicMock()
+        service.metadata = AsyncMock(
+            side_effect=[{"orders": topic}, KafkaException("metadata unavailable")]
+        )
+        service.enrich_offsets = AsyncMock(return_value=EnrichmentResult())
+        service.load_groups = AsyncMock(return_value=GroupSnapshot())
+        service.apply_groups.return_value = EnrichmentResult()
+
+        with patch("kaskade.admin.TopicService", return_value=service):
+            app = KaskadeAdmin({})
+            async with app.run_test() as pilot:
+                await app.workers.wait_for_complete()
+                table = app.query_one(DataTable)
+                topics = app.query_one(ListTopics)
+
+                topics.request_refresh(RefreshReason.MANUAL)
+                await app.workers.wait_for_complete()
+                await pilot.pause()
+
+                self.assertEqual("≈10", table.get_cell("orders", "records"))
+                self.assertIs(topic, topics.topics["orders"])
+
+    async def test_refresh_preserves_filter_selection_and_completed_metrics(self) -> None:
+        previous = Topic(
+            name="payments",
+            partitions=[Partition(id=0, high=25)],
+            records_state=MetricState.READY,
+            groups_state=MetricState.READY,
+        )
+        refreshed = Topic(name="payments", partitions=[Partition(id=0)])
+        service = MagicMock()
+        service.metadata = AsyncMock(
+            side_effect=[
+                {"orders": Topic(name="orders"), "payments": previous},
+                {"payments": refreshed},
+            ]
+        )
+        service.enrich_offsets = AsyncMock(return_value=EnrichmentResult())
+        service.load_groups = AsyncMock(return_value=GroupSnapshot())
+        service.apply_groups.return_value = EnrichmentResult()
+
+        with patch("kaskade.admin.TopicService", return_value=service):
+            app = KaskadeAdmin({})
+            async with app.run_test() as pilot:
+                await app.workers.wait_for_complete()
+                topics = app.query_one(ListTopics)
+                topics.current_filter = "payments"
+                topics.current_topic = previous
+                topics.fill_table()
+
+                topics.request_refresh(RefreshReason.MANUAL)
+                await app.workers.wait_for_complete()
+                await pilot.pause()
+
+                table = app.query_one(DataTable)
+                self.assertEqual("payments", topics.current_filter)
+                self.assertEqual("payments", topics.current_topic.name)
+                self.assertEqual("≈25", table.get_cell("payments", "records"))

--- a/tests/tests_admin.py
+++ b/tests/tests_admin.py
@@ -69,6 +69,18 @@ class TestCreateTopic(unittest.IsolatedAsyncioTestCase):
 
 
 class TestAdminRefresh(unittest.IsolatedAsyncioTestCase):
+    async def test_command_line_interval_overrides_config(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            config_path = Path(temporary_directory) / "config.yaml"
+            config_path.write_text(
+                "admin:\n  refresh_interval_seconds: 60\n",
+                encoding="utf-8",
+            )
+            with patch.dict(os.environ, {CONFIG_ENV_VAR: str(config_path)}):
+                app = KaskadeAdmin({}, refresh_interval=10)
+
+                self.assertEqual(10, app.auto_refresh_interval)
+
     async def test_can_disable_auto_refresh(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             config_path = Path(temporary_directory) / "config.yaml"

--- a/tests/tests_admin.py
+++ b/tests/tests_admin.py
@@ -1,17 +1,25 @@
+import asyncio
+import os
+import tempfile
 import unittest
-from unittest.mock import AsyncMock, patch
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from confluent_kafka import KafkaException
 from confluent_kafka.cimpl import NewTopic
 from textual.widgets import DataTable, Input
 
-from kaskade.admin import CreateTopicScreen, KaskadeAdmin, ListTopics
+from kaskade.admin import CreateTopicScreen, FilterTopicsScreen, KaskadeAdmin, ListTopics
+from kaskade.keymaps import CONFIG_ENV_VAR
+from kaskade.models import MetricState, Partition, Topic
+from kaskade.services import EnrichmentResult, GroupSnapshot
+from tests import configure_admin_service
 
 
 class TestCreateTopic(unittest.IsolatedAsyncioTestCase):
     async def test_keeps_invalid_topic_configuration_open(self) -> None:
         with patch("kaskade.admin.TopicService") as topic_service:
-            topic_service.return_value.all = AsyncMock(return_value={})
+            configure_admin_service(topic_service.return_value, {})
             app = KaskadeAdmin({})
             results: list[NewTopic | None] = []
 
@@ -44,7 +52,7 @@ class TestCreateTopic(unittest.IsolatedAsyncioTestCase):
 
     async def test_stops_loading_when_kafka_rejects_topic(self) -> None:
         with patch("kaskade.admin.TopicService") as topic_service:
-            topic_service.return_value.all = AsyncMock(return_value={})
+            configure_admin_service(topic_service.return_value, {})
             topic_service.return_value.create.side_effect = KafkaException("invalid topic")
             app = KaskadeAdmin({})
 
@@ -58,3 +66,97 @@ class TestCreateTopic(unittest.IsolatedAsyncioTestCase):
                 await pilot.pause()
 
                 self.assertFalse(table.loading)
+
+
+class TestAdminRefresh(unittest.IsolatedAsyncioTestCase):
+    async def test_can_disable_auto_refresh(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            config_path = Path(temporary_directory) / "config.yaml"
+            config_path.write_text(
+                "admin:\n  refresh_interval_seconds: 0\n",
+                encoding="utf-8",
+            )
+            with (
+                patch.dict(os.environ, {CONFIG_ENV_VAR: str(config_path)}),
+                patch("kaskade.admin.TopicService") as topic_service,
+            ):
+                configure_admin_service(topic_service.return_value, {})
+                app = KaskadeAdmin({})
+                async with app.run_test() as pilot:
+                    await app.workers.wait_for_complete()
+                    await pilot.pause()
+
+                    self.assertEqual(0, app.auto_refresh_interval)
+                    self.assertIsNone(app._auto_refresh_timer)
+                    self.assertIn("Auto Off", app.query_one(DataTable).border_subtitle)
+
+    async def test_renders_metadata_before_metrics_finish(self) -> None:
+        offsets_gate = asyncio.Event()
+        groups_gate = asyncio.Event()
+        topic = Topic(
+            name="orders",
+            partitions=[Partition(id=0, replicas=[0, 1], isrs=[0, 1])],
+        )
+        service = MagicMock()
+        service.metadata = AsyncMock(return_value={"orders": topic})
+
+        async def enrich_offsets(topics: dict[str, Topic]) -> EnrichmentResult:
+            await offsets_gate.wait()
+            topics["orders"].partitions[0].high = 10
+            topics["orders"].records_state = MetricState.READY
+            return EnrichmentResult()
+
+        async def load_groups() -> GroupSnapshot:
+            await groups_gate.wait()
+            return GroupSnapshot()
+
+        service.enrich_offsets.side_effect = enrich_offsets
+        service.load_groups.side_effect = load_groups
+        service.apply_groups.side_effect = lambda topics, snapshot: EnrichmentResult()
+
+        with patch("kaskade.admin.TopicService", return_value=service):
+            app = KaskadeAdmin({})
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                table = app.query_one("#topics-table", DataTable)
+
+                self.assertEqual(1, len(table.rows))
+                self.assertEqual("…", table.get_cell("orders", "records"))
+                offsets_gate.set()
+                await pilot.pause()
+                self.assertEqual("≈10", table.get_cell("orders", "records"))
+                groups_gate.set()
+                await app.workers.wait_for_complete()
+
+    async def test_periodic_refresh_does_not_overlap_and_resumes_after_modal(self) -> None:
+        gate = asyncio.Event()
+        service = MagicMock()
+
+        async def metadata() -> dict[str, Topic]:
+            await gate.wait()
+            return {}
+
+        service.metadata.side_effect = metadata
+        service.enrich_offsets = AsyncMock(return_value=EnrichmentResult())
+        service.load_groups = AsyncMock(return_value=GroupSnapshot())
+        service.apply_groups.return_value = EnrichmentResult()
+
+        with patch("kaskade.admin.TopicService", return_value=service):
+            app = KaskadeAdmin({})
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                app._request_periodic_refresh()
+                self.assertEqual(1, service.metadata.call_count)
+                gate.set()
+                await app.workers.wait_for_complete()
+
+                service.metadata.reset_mock()
+                app.push_screen(FilterTopicsScreen())
+                await pilot.pause()
+                app._request_periodic_refresh()
+                self.assertEqual(0, service.metadata.call_count)
+
+                app.pop_screen()
+                await asyncio.sleep(0.2)
+                await pilot.pause()
+                self.assertEqual(1, service.metadata.call_count)

--- a/tests/tests_deserializers.py
+++ b/tests/tests_deserializers.py
@@ -47,8 +47,23 @@ class TestDeserializer(unittest.TestCase):
     def test_missing_deserializer_configuration_raises_deserialization_error(self):
         pool = DeserializerPool()
 
-        with self.assertRaisesRegex(DeserializationError, "Schema Registry is not configured"):
-            pool.get(Deserialization.REGISTRY)
+        missing_configurations = {
+            Deserialization.REGISTRY: "Schema Registry is not configured",
+            Deserialization.AVRO: "Avro is not configured",
+            Deserialization.PROTOBUF: "Protobuf is not configured",
+        }
+        for deserialization, message in missing_configurations.items():
+            with (
+                self.subTest(deserialization=deserialization),
+                self.assertRaisesRegex(DeserializationError, message),
+            ):
+                pool.get(deserialization)
+
+    def test_pool_reuses_configured_deserializers(self):
+        pool = DeserializerPool()
+
+        self.assertIs(pool.get(Deserialization.STRING), pool.get(Deserialization.STRING))
+        self.assertIs(pool.default_deserializer, pool.get(Deserialization.BYTES))
 
     def test_header_falls_back_to_binary_value_for_deserialization_error(self):
         value = b"invalid"

--- a/tests/tests_deserializers.py
+++ b/tests/tests_deserializers.py
@@ -22,7 +22,7 @@ from kaskade.deserializers import (
     RegistryDeserializer,
     StringDeserializer,
 )
-from kaskade.models import Header
+from kaskade.models import Header, Record
 from kaskade.utils import file_to_str, py_to_avro
 from tests import faker
 from tests.protobuf_model.user_pb2 import User
@@ -57,6 +57,28 @@ class TestDeserializer(unittest.TestCase):
         header = Header(value=value, value_deserializer=deserializer)
 
         self.assertEqual(str(value), header.value_deserialized())
+        self.assertEqual(str(value), header.value_deserialized())
+        deserializer.deserialize.assert_called_once_with(value)
+
+    def test_record_caches_successful_deserialization(self):
+        key_deserializer = MagicMock()
+        key_deserializer.deserialize.return_value = "customer-1"
+        value_deserializer = MagicMock()
+        value_deserializer.deserialize.return_value = {"total": 10}
+        record = Record(
+            topic="orders",
+            key=b"customer-1",
+            value=b"payload",
+            key_deserializer=key_deserializer,
+            value_deserializer=value_deserializer,
+        )
+
+        self.assertEqual("customer-1", record.key_str())
+        self.assertEqual("customer-1", record.key_str())
+        self.assertEqual("{'total': 10}", record.value_str())
+        self.assertEqual("{'total': 10}", record.value_str())
+        key_deserializer.deserialize.assert_called_once()
+        value_deserializer.deserialize.assert_called_once()
 
     def test_header_propagates_unexpected_errors(self):
         deserializer = MagicMock()

--- a/tests/tests_keymaps.py
+++ b/tests/tests_keymaps.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 from textual.widgets import DataTable
 
@@ -26,6 +26,7 @@ from kaskade.keymaps import CONFIG_ENV_VAR, KNOWN_BINDING_IDS, default_config_pa
 from kaskade.models import Topic
 from kaskade.themes import KaskadeApp
 from kaskade.widgets import KaskadeOptionList, KaskadeScrollableContainer, StretchyDataTable
+from tests import configure_admin_service
 
 
 class TestKeymapConfiguration(unittest.TestCase):
@@ -119,6 +120,49 @@ class TestKeymapConfiguration(unittest.TestCase):
         )
         self.assertEqual((), settings.warnings)
 
+    def test_loads_admin_refresh_interval(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            path = Path(temporary_directory) / "config.yaml"
+            path.write_text(
+                "admin:\n  refresh_interval_seconds: 10\n",
+                encoding="utf-8",
+            )
+
+            settings = load_keymap(path)
+
+        self.assertEqual(10, settings.admin_refresh_interval_seconds)
+        self.assertEqual((), settings.warnings)
+
+    def test_disables_admin_refresh_with_zero(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            path = Path(temporary_directory) / "config.yaml"
+            path.write_text(
+                "admin:\n  refresh_interval_seconds: 0\n",
+                encoding="utf-8",
+            )
+
+            settings = load_keymap(path)
+
+        self.assertEqual(0, settings.admin_refresh_interval_seconds)
+
+    def test_invalid_admin_refresh_uses_default_without_discarding_keymap(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            path = Path(temporary_directory) / "config.yaml"
+            path.write_text(
+                """admin:
+  refresh_interval_seconds: 2
+keymap:
+  app.quit: x
+""",
+                encoding="utf-8",
+            )
+
+            settings = load_keymap(path)
+
+        self.assertEqual(30, settings.admin_refresh_interval_seconds)
+        self.assertEqual({"app.quit": "x"}, settings.keymap)
+        self.assertEqual(1, len(settings.warnings))
+
     def test_ignores_invalid_entries_without_discarding_valid_ones(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             path = Path(temporary_directory) / "config.yaml"
@@ -186,11 +230,12 @@ class TestConfiguredKeymap(unittest.IsolatedAsyncioTestCase):
                 patch.dict(os.environ, {CONFIG_ENV_VAR: str(path)}),
                 patch("kaskade.admin.TopicService") as topic_service,
             ):
-                topic_service.return_value.all = AsyncMock(
-                    return_value={
+                configure_admin_service(
+                    topic_service.return_value,
+                    {
                         "alpha": Topic(name="alpha"),
                         "bravo": Topic(name="bravo"),
-                    }
+                    },
                 )
                 app = KaskadeAdmin({})
 

--- a/tests/tests_keymaps.py
+++ b/tests/tests_keymaps.py
@@ -22,7 +22,15 @@ from kaskade.consumer import (
     TopicScreen,
 )
 from kaskade.help import HelpableModalScreen, HelpScreen
-from kaskade.keymaps import CONFIG_ENV_VAR, KNOWN_BINDING_IDS, default_config_path, load_keymap
+from kaskade.keymaps import (
+    CONFIG_ENV_VAR,
+    KNOWN_BINDING_IDS,
+    AppSettings,
+    KeymapSettings,
+    default_config_path,
+    load_keymap,
+    load_settings,
+)
 from kaskade.models import Topic
 from kaskade.themes import KaskadeApp
 from kaskade.widgets import KaskadeOptionList, KaskadeScrollableContainer, StretchyDataTable
@@ -30,6 +38,17 @@ from tests import configure_admin_service
 
 
 class TestKeymapConfiguration(unittest.TestCase):
+    def test_preserves_original_settings_names_as_aliases(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            path = Path(temporary_directory) / "config.yaml"
+            path.write_text("admin:\n  refresh_interval_seconds: 10\n", encoding="utf-8")
+
+            settings = load_settings(path)
+            compatibility_settings = load_keymap(path)
+
+        self.assertIs(AppSettings, KeymapSettings)
+        self.assertEqual(settings, compatibility_settings)
+
     def test_every_kaskade_binding_id_is_configurable(self):
         binding_owners = (
             KaskadeApp,

--- a/tests/tests_main.py
+++ b/tests/tests_main.py
@@ -46,7 +46,9 @@ class TestAdminCli(unittest.TestCase):
     def test_update_kafka_config(self, mock_class_kaskade_admin):
         result = self.runner.invoke(cli, [self.command, "-b", EXPECTED_SERVER])
 
-        mock_class_kaskade_admin.assert_called_with({BOOTSTRAP_SERVERS: EXPECTED_SERVER})
+        mock_class_kaskade_admin.assert_called_with(
+            {BOOTSTRAP_SERVERS: EXPECTED_SERVER}, refresh_interval=None
+        )
         self.assertEqual(0, result.exit_code)
 
     @patch("kaskade.main.KaskadeAdmin")
@@ -56,7 +58,8 @@ class TestAdminCli(unittest.TestCase):
         )
 
         mock_class_kaskade_admin.assert_called_with(
-            {BOOTSTRAP_SERVERS: EXPECTED_SERVER, "security.protocol": "SSL"}
+            {BOOTSTRAP_SERVERS: EXPECTED_SERVER, "security.protocol": "SSL"},
+            refresh_interval=None,
         )
         self.assertEqual(0, result.exit_code)
 
@@ -76,7 +79,8 @@ class TestAdminCli(unittest.TestCase):
         )
 
         mock_class_kaskade_admin.assert_called_with(
-            {BOOTSTRAP_SERVERS: EXPECTED_SERVER, "security.protocol": "SASL_SSL"}
+            {BOOTSTRAP_SERVERS: EXPECTED_SERVER, "security.protocol": "SASL_SSL"},
+            refresh_interval=None,
         )
         self.assertEqual(0, result.exit_code)
 
@@ -105,6 +109,39 @@ class TestAdminCli(unittest.TestCase):
         self.assertIn("Invalid value for '--theme'", result.output)
 
     @patch("kaskade.main.KaskadeAdmin")
+    def test_pass_refresh_interval(self, mock_class_kaskade_admin):
+        result = self.runner.invoke(
+            cli,
+            [self.command, "-b", EXPECTED_SERVER, "--refresh-interval", "10"],
+        )
+
+        mock_class_kaskade_admin.assert_called_with(
+            {BOOTSTRAP_SERVERS: EXPECTED_SERVER}, refresh_interval=10
+        )
+        self.assertEqual(0, result.exit_code)
+
+    @patch("kaskade.main.KaskadeAdmin")
+    def test_disable_refresh_interval(self, mock_class_kaskade_admin):
+        result = self.runner.invoke(
+            cli,
+            [self.command, "-b", EXPECTED_SERVER, "--refresh-interval", "0"],
+        )
+
+        mock_class_kaskade_admin.assert_called_with(
+            {BOOTSTRAP_SERVERS: EXPECTED_SERVER}, refresh_interval=0
+        )
+        self.assertEqual(0, result.exit_code)
+
+    def test_reject_refresh_interval_below_minimum(self):
+        result = self.runner.invoke(
+            cli,
+            [self.command, "-b", EXPECTED_SERVER, "--refresh-interval", "4"],
+        )
+
+        self.assertGreater(result.exit_code, 0)
+        self.assertIn("Should be 0 or at least 5 seconds", result.output)
+
+    @patch("kaskade.main.KaskadeAdmin")
     def test_update_kafka_config_with_extra_config(self, mock_class_kaskade_admin):
         expected_property_name = "property.name"
         expected_property_value = "property.value"
@@ -121,7 +158,8 @@ class TestAdminCli(unittest.TestCase):
         )
 
         mock_class_kaskade_admin.assert_called_with(
-            {BOOTSTRAP_SERVERS: EXPECTED_SERVER, expected_property_name: expected_property_value}
+            {BOOTSTRAP_SERVERS: EXPECTED_SERVER, expected_property_name: expected_property_value},
+            refresh_interval=None,
         )
         self.assertEqual(0, result.exit_code)
 
@@ -150,7 +188,8 @@ class TestAdminCli(unittest.TestCase):
                 BOOTSTRAP_SERVERS: EXPECTED_SERVER,
                 expected_property_name: expected_property_value,
                 expected_property_name2: expected_property_value2,
-            }
+            },
+            refresh_interval=None,
         )
         self.assertEqual(0, result.exit_code)
 

--- a/tests/tests_services.py
+++ b/tests/tests_services.py
@@ -3,7 +3,7 @@ import unittest
 from concurrent.futures import Future
 from unittest.mock import MagicMock, patch
 
-from confluent_kafka import ConsumerGroupTopicPartitions, Node
+from confluent_kafka import ConsumerGroupTopicPartitions, KafkaException, Node
 from confluent_kafka.admin import (
     ConsumerGroupDescription,
     ConsumerGroupListing,
@@ -16,7 +16,7 @@ from confluent_kafka.admin import (
 )
 from confluent_kafka.cimpl import CONSUMER_GROUP_STATE_STABLE, TopicPartition
 
-from kaskade.deserializers import Deserialization, DeserializerPool
+from kaskade.deserializers import Deserialization, DeserializerPool, StringDeserializer
 from kaskade.models import MetricState
 from kaskade.services import ConsumerService, TopicService
 from tests import faker
@@ -46,6 +46,25 @@ def topic_metadata(name: str, partition_id: int, partition_count: int = 1) -> To
         partition.replicas = [0, 1, 2]
         topic.partitions[current_partition_id] = partition
     return topic
+
+
+def consumer_message(
+    *,
+    partition: int = 0,
+    key: bytes = b"key",
+    value: bytes = b"value",
+    headers: list[tuple[str, bytes]] | None = None,
+    error: object | None = None,
+) -> MagicMock:
+    message = MagicMock()
+    message.error.return_value = error
+    message.timestamp.return_value = (0, 0)
+    message.partition.return_value = partition
+    message.offset.return_value = 1
+    message.key.return_value = key
+    message.value.return_value = value
+    message.headers.return_value = headers or []
+    return message
 
 
 class TestTopicService(unittest.IsolatedAsyncioTestCase):
@@ -227,6 +246,102 @@ class TestConsumerService(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(1, len(records))
         self.assertEqual("key", records[0].key_str())
         consumer.consume.assert_called_once_with(1, timeout=service.timeout)
+
+    @patch("kaskade.services.Consumer")
+    async def test_filters_batches_until_a_record_matches(
+        self, mock_class_consumer: MagicMock
+    ) -> None:
+        consumer = mock_class_consumer.return_value
+        consumer.consume.side_effect = [
+            [consumer_message(partition=0)],
+            [
+                consumer_message(
+                    partition=1,
+                    key=b"customer-1",
+                    value=b"paid",
+                    headers=[("source", b"checkout")],
+                )
+            ],
+        ]
+        service = ConsumerService(
+            "orders",
+            {"bootstrap.servers": "localhost:9092"},
+            DeserializerPool(),
+            Deserialization.STRING,
+            Deserialization.STRING,
+            page_size=1,
+        )
+        service.on_assign(consumer, [TopicPartition("orders", 1)])
+
+        records = await service.consume(
+            partition_filter=1,
+            key_filter="customer",
+            value_filter="paid",
+            header_filter="checkout",
+        )
+
+        self.assertEqual(1, len(records))
+        self.assertEqual(2, consumer.consume.call_count)
+
+    @patch("kaskade.services.Consumer")
+    async def test_stops_after_empty_batch_retries(self, mock_class_consumer: MagicMock) -> None:
+        consumer = mock_class_consumer.return_value
+        consumer.consume.return_value = []
+        service = ConsumerService(
+            "orders",
+            {"bootstrap.servers": "localhost:9092"},
+            DeserializerPool(),
+            Deserialization.STRING,
+            Deserialization.STRING,
+            poll_retries=2,
+        )
+        service.on_assign(consumer, [TopicPartition("orders", 0)])
+
+        self.assertEqual([], await service.consume())
+        self.assertEqual(2, consumer.consume.call_count)
+
+    @patch("kaskade.services.Consumer")
+    async def test_raises_kafka_message_errors(self, mock_class_consumer: MagicMock) -> None:
+        error = MagicMock()
+        consumer = mock_class_consumer.return_value
+        consumer.consume.return_value = [consumer_message(error=error)]
+        service = ConsumerService(
+            "orders",
+            {"bootstrap.servers": "localhost:9092"},
+            DeserializerPool(),
+            Deserialization.STRING,
+            Deserialization.STRING,
+            page_size=1,
+        )
+        service.on_assign(consumer, [TopicPartition("orders", 0)])
+
+        with self.assertRaises(KafkaException):
+            await service.consume()
+
+    @patch("kaskade.services.Consumer")
+    async def test_reuses_deserializer_instances_and_closes(
+        self, mock_class_consumer: MagicMock
+    ) -> None:
+        consumer = mock_class_consumer.return_value
+        consumer.consume.return_value = [consumer_message()]
+        deserializer_factory = MagicMock(spec=DeserializerPool)
+        deserializer_factory.get.return_value = StringDeserializer()
+        service = ConsumerService(
+            "orders",
+            {"bootstrap.servers": "localhost:9092"},
+            deserializer_factory,
+            Deserialization.STRING,
+            Deserialization.STRING,
+            page_size=1,
+        )
+        service.on_assign(consumer, [TopicPartition("orders", 0)])
+
+        await service.consume()
+        service.close()
+
+        self.assertEqual(3, deserializer_factory.get.call_count)
+        consumer.unsubscribe.assert_called_once_with()
+        consumer.close.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/tests/tests_services.py
+++ b/tests/tests_services.py
@@ -1,10 +1,14 @@
+import asyncio
 import unittest
+from concurrent.futures import Future
 from unittest.mock import MagicMock, patch
 
-from confluent_kafka import Node
+from confluent_kafka import ConsumerGroupTopicPartitions, Node
 from confluent_kafka.admin import (
     ConsumerGroupDescription,
     ConsumerGroupListing,
+    ListConsumerGroupsResult,
+    ListOffsetsResultInfo,
     MemberAssignment,
     MemberDescription,
     PartitionMetadata,
@@ -12,176 +16,217 @@ from confluent_kafka.admin import (
 )
 from confluent_kafka.cimpl import CONSUMER_GROUP_STATE_STABLE, TopicPartition
 
-from kaskade.services import TopicService
+from kaskade.deserializers import Deserialization, DeserializerPool
+from kaskade.models import MetricState
+from kaskade.services import ConsumerService, TopicService
 from tests import faker
 
 
+def completed(value: object) -> Future[object]:
+    future: Future[object] = Future()
+    future.set_result(value)
+    return future
+
+
+def failed(error: Exception) -> Future[object]:
+    future: Future[object] = Future()
+    future.set_exception(error)
+    return future
+
+
+def topic_metadata(name: str, partition_id: int, partition_count: int = 1) -> TopicMetadata:
+    topic = TopicMetadata()
+    topic.topic = name
+    topic.partitions = {}
+    for current_partition_id in range(partition_id, partition_id + partition_count):
+        partition = PartitionMetadata()
+        partition.id = current_partition_id
+        partition.leader = 0
+        partition.isrs = [0, 1]
+        partition.replicas = [0, 1, 2]
+        topic.partitions[current_partition_id] = partition
+    return topic
+
+
 class TestTopicService(unittest.IsolatedAsyncioTestCase):
+    @patch("kaskade.services.Consumer")
+    @patch("kaskade.services.AdminClient")
+    async def test_batches_offsets_without_admin_consumers(
+        self, mock_class_admin: MagicMock, mock_class_consumer: MagicMock
+    ) -> None:
+        topic_name = faker.word()
+        partition_id = faker.pyint()
+        metadata = topic_metadata(topic_name, partition_id, partition_count=25)
+        admin = mock_class_admin.return_value
+        admin.list_topics.return_value.topics = {topic_name: metadata}
+
+        def list_offsets(request: dict[TopicPartition, object], **_: object) -> object:
+            offset = 0 if admin.list_offsets.call_count == 1 else 50
+            return {
+                partition: completed(ListOffsetsResultInfo(offset, -1, -1)) for partition in request
+            }
+
+        admin.list_offsets.side_effect = list_offsets
+        admin.list_consumer_groups.return_value = completed(ListConsumerGroupsResult(valid=[]))
+
+        topics = await TopicService({"bootstrap.servers": faker.hostname()}).all()
+
+        topic = topics[topic_name]
+        self.assertEqual(MetricState.READY, topic.records_state)
+        self.assertEqual(MetricState.READY, topic.groups_state)
+        self.assertEqual(1250, topic.records_count())
+        self.assertEqual(2, admin.list_offsets.call_count)
+        mock_class_consumer.assert_not_called()
 
     @patch("kaskade.services.Consumer")
     @patch("kaskade.services.AdminClient")
-    async def test_get_topics_without_group(self, mock_class_admin, mock_class_consumer):
-        # prepare get_watermark
-        expected_low_watermark = 0
-        expected_high_watermark = 50
+    async def test_maps_groups_with_one_offset_request_per_group(
+        self, mock_class_admin: MagicMock, mock_class_consumer: MagicMock
+    ) -> None:
+        topic_name = faker.word()
+        partition_id = faker.pyint()
+        metadata = topic_metadata(topic_name, partition_id)
+        admin = mock_class_admin.return_value
+        admin.list_topics.return_value.topics = {topic_name: metadata}
 
-        mock_consumer = MagicMock()
-        mock_class_consumer.return_value = mock_consumer
-        mock_consumer.get_watermark_offsets.return_value = (
-            expected_low_watermark,
-            expected_high_watermark,
+        def list_offsets(request: dict[TopicPartition, object], **_: object) -> object:
+            offset = 0 if admin.list_offsets.call_count == 1 else 50
+            return {
+                partition: completed(ListOffsetsResultInfo(offset, -1, -1)) for partition in request
+            }
+
+        admin.list_offsets.side_effect = list_offsets
+        group_id = faker.word()
+        committed = TopicPartition(topic_name, partition_id, 30)
+        member = MemberDescription(
+            member_id=f"{group_id}-1",
+            client_id=f"{group_id}-client",
+            host=faker.hostname(),
+            assignment=MemberAssignment([committed]),
         )
-
-        # prepare topic: 1 topic and 1 partition
-        expected_topic_name = faker.word()
-
-        partition_metadata = PartitionMetadata()
-        partition_metadata.id = faker.pyint()
-        partition_metadata.isrs = [0, 1]
-        partition_metadata.replicas = [0, 1, 2]
-
-        topic_metadata = TopicMetadata()
-        topic_metadata.topic = expected_topic_name
-        topic_metadata.partitions = {partition_metadata.id: partition_metadata}
-
-        # prepare list_topics
-        mock_admin = MagicMock()
-        mock_class_admin.return_value = mock_admin
-        mock_admin.list_topics.return_value.topics = {topic_metadata.topic: topic_metadata}
-
-        # prepare consumer groups: no groups
-        mock_admin.list_consumer_groups.return_value.result.return_value.valid = []
-
-        # asserts
-        topic_service = TopicService({"bootstrap.servers": faker.hostname()})
-
-        topics_list = await topic_service.all()
-        self.assertEqual(1, len(topics_list))
-
-        topic = topics_list[expected_topic_name]
-        self.assertEqual(expected_topic_name, topic.name)
-
-        partitions_list = topic.partitions
-        self.assertEqual(1, len(partitions_list))
-
-        partition = partitions_list[0]
-        self.assertEqual(expected_low_watermark, partition.low)
-        self.assertEqual(expected_high_watermark, partition.high)
-
-        groups_list = topic.groups
-        self.assertEqual(0, len(groups_list))
-
-        self.assertEqual(0, topic.groups_count())
-        self.assertEqual(1, topic.partitions_count())
-        self.assertEqual(2, topic.isrs_count())
-        self.assertEqual(50, topic.records_count())
-        self.assertEqual(3, topic.replicas_count())
-        self.assertEqual(0, topic.lag())
-
-    @patch("kaskade.services.Consumer")
-    @patch("kaskade.services.AdminClient")
-    async def test_get_topics_with_group(self, mock_class_admin, mock_class_consumer):
-        # prepare get_watermark
-        expected_low_watermark = 0
-        expected_high_watermark = 50
-
-        mock_consumer = MagicMock()
-        mock_class_consumer.return_value = mock_consumer
-        mock_consumer.get_watermark_offsets.return_value = (
-            expected_low_watermark,
-            expected_high_watermark,
-        )
-
-        # prepare topic: 1 topic and 1 partition
-        expected_topic_name = faker.word()
-
-        partition_metadata = PartitionMetadata()
-        partition_metadata.id = faker.pyint()
-        partition_metadata.isrs = [0, 1]
-        partition_metadata.replicas = [0, 1, 2]
-
-        topic_metadata = TopicMetadata()
-        topic_metadata.topic = expected_topic_name
-        topic_metadata.partitions = {partition_metadata.id: partition_metadata}
-
-        # prepare list_topics
-        mock_admin = MagicMock()
-        mock_class_admin.return_value = mock_admin
-        mock_admin.list_topics.return_value.topics = {topic_metadata.topic: topic_metadata}
-
-        # prepare consumer groups: no groups
-        expected_group_name = faker.word()
-        expected_partition_assignor = faker.word()
-        expected_member_id = expected_group_name + "-1"
-        expected_client_id = expected_group_name + "-client"
-        expected_host = faker.hostname()
-        expected_node_id = 1
-        expected_node_port = 9092
-        expected_offset = 30
-
-        committed_partition_metadata = TopicPartition(
-            expected_topic_name, partition_metadata.id, expected_offset
-        )
-        consume_group_assignment = MemberAssignment([committed_partition_metadata])
-        consumer_group_member_metadata = MemberDescription(
-            member_id=expected_member_id,
-            client_id=expected_client_id,
-            host=expected_host,
-            assignment=consume_group_assignment,
-        )
-        consumer_group_node_metadata = Node(expected_node_id, expected_host, expected_node_port)
-        consumer_group_metadata = ConsumerGroupDescription(
-            group_id=expected_group_name,
+        description = ConsumerGroupDescription(
+            group_id=group_id,
             is_simple_consumer_group=True,
-            partition_assignor=expected_partition_assignor,
+            partition_assignor="range",
             state=CONSUMER_GROUP_STATE_STABLE,
-            members=[consumer_group_member_metadata],
-            coordinator=consumer_group_node_metadata,
+            members=[member],
+            coordinator=Node(1, faker.hostname(), 9092),
         )
+        admin.list_consumer_groups.return_value = completed(
+            ListConsumerGroupsResult(valid=[ConsumerGroupListing(group_id, True)])
+        )
+        admin.describe_consumer_groups.return_value = {group_id: completed(description)}
+        admin.list_consumer_group_offsets.return_value = {
+            group_id: completed(ConsumerGroupTopicPartitions(group_id, [committed]))
+        }
 
-        mock_describe_consumer_result = MagicMock()
-        mock_describe_consumer_result.result.return_value = consumer_group_metadata
-        mock_admin.list_consumer_groups.return_value.result.return_value.valid = [
-            ConsumerGroupListing(expected_group_name, True)
-        ]
-        mock_admin.describe_consumer_groups.return_value.items.return_value = [
-            (expected_group_name, mock_describe_consumer_result)
-        ]
-        mock_consumer.committed.return_value = [committed_partition_metadata]
+        topics = await TopicService({"bootstrap.servers": faker.hostname()}).all()
 
-        # asserts
-        topic_service = TopicService({"bootstrap.servers": faker.hostname()})
-
-        topics_list = await topic_service.all()
-        self.assertEqual(1, len(topics_list))
-
-        topic = topics_list[expected_topic_name]
-        self.assertEqual(expected_topic_name, topic.name)
-
-        partitions_list = topic.partitions
-        self.assertEqual(1, len(partitions_list))
-
-        partition = partitions_list[0]
-        self.assertEqual(expected_low_watermark, partition.low)
-        self.assertEqual(expected_high_watermark, partition.high)
-
-        groups_list = topic.groups
-        self.assertEqual(1, len(groups_list))
-
-        group = groups_list[0]
-        self.assertEqual(1, group.partitions_count())
-        self.assertEqual(1, group.members_count())
-        self.assertEqual(20, group.lag_count())
-
-        member = group.members[0]
-        self.assertEqual(expected_member_id, member.id)
-
+        topic = topics[topic_name]
         self.assertEqual(1, topic.groups_count())
-        self.assertEqual(1, topic.partitions_count())
-        self.assertEqual(2, topic.isrs_count())
-        self.assertEqual(50, topic.records_count())
-        self.assertEqual(3, topic.replicas_count())
+        self.assertEqual(1, topic.group_members_count())
         self.assertEqual(20, topic.lag())
+        self.assertEqual(1, admin.list_consumer_group_offsets.call_count)
+        mock_class_consumer.assert_not_called()
+
+    @patch("kaskade.services.AdminClient")
+    async def test_marks_failed_metrics_unavailable(self, mock_class_admin: MagicMock) -> None:
+        topic_name = "orders"
+        metadata = topic_metadata(topic_name, 0)
+        admin = mock_class_admin.return_value
+        admin.list_topics.return_value.topics = {topic_name: metadata}
+
+        def list_offsets(request: dict[TopicPartition, object], **_: object) -> object:
+            if admin.list_offsets.call_count == 1:
+                return {partition: failed(RuntimeError("unavailable")) for partition in request}
+            return {
+                partition: completed(ListOffsetsResultInfo(50, -1, -1)) for partition in request
+            }
+
+        admin.list_offsets.side_effect = list_offsets
+        admin.list_consumer_groups.return_value = completed(ListConsumerGroupsResult(valid=[]))
+
+        topic = (await TopicService({"bootstrap.servers": "localhost:9092"}).all())[topic_name]
+
+        self.assertEqual(MetricState.UNAVAILABLE, topic.records_state)
+        self.assertEqual(MetricState.UNAVAILABLE, topic.groups_state)
+
+    @patch("kaskade.services.AdminClient")
+    async def test_bounds_group_offset_concurrency(self, mock_class_admin: MagicMock) -> None:
+        admin = mock_class_admin.return_value
+        group_ids = [f"group-{index}" for index in range(20)]
+        admin.list_consumer_groups.return_value = completed(
+            ListConsumerGroupsResult(
+                valid=[ConsumerGroupListing(group_id, True) for group_id in group_ids]
+            )
+        )
+        admin.describe_consumer_groups.return_value = {
+            group_id: completed(
+                ConsumerGroupDescription(
+                    group_id=group_id,
+                    is_simple_consumer_group=True,
+                    partition_assignor="range",
+                    state=CONSUMER_GROUP_STATE_STABLE,
+                    members=[],
+                    coordinator=Node(1, "localhost", 9092),
+                )
+            )
+            for group_id in group_ids
+        }
+        pending: dict[str, Future[object]] = {}
+
+        def list_group_offsets(request: list[ConsumerGroupTopicPartitions], **_: object) -> object:
+            group_id = request[0].group_id
+            future: Future[object] = Future()
+            pending[group_id] = future
+            return {group_id: future}
+
+        admin.list_consumer_group_offsets.side_effect = list_group_offsets
+        service = TopicService({"bootstrap.servers": "localhost:9092"})
+        task = asyncio.create_task(service.load_groups())
+        for _ in range(100):
+            if len(pending) == service.GROUP_OFFSET_CONCURRENCY:
+                break
+            await asyncio.sleep(0)
+
+        self.assertEqual(service.GROUP_OFFSET_CONCURRENCY, len(pending))
+        while not task.done():
+            for group_id, future in list(pending.items()):
+                if not future.done():
+                    future.set_result(ConsumerGroupTopicPartitions(group_id, []))
+            await asyncio.sleep(0)
+        await task
+        self.assertEqual(len(group_ids), admin.list_consumer_group_offsets.call_count)
+
+
+class TestConsumerService(unittest.IsolatedAsyncioTestCase):
+    @patch("kaskade.services.Consumer")
+    async def test_consumes_records_in_batches(self, mock_class_consumer: MagicMock) -> None:
+        message = MagicMock()
+        message.error.return_value = None
+        message.timestamp.return_value = (0, 0)
+        message.partition.return_value = 0
+        message.offset.return_value = 1
+        message.key.return_value = b"key"
+        message.value.return_value = b"value"
+        message.headers.return_value = []
+        consumer = mock_class_consumer.return_value
+        consumer.consume.return_value = [message]
+        service = ConsumerService(
+            "orders",
+            {"bootstrap.servers": "localhost:9092"},
+            DeserializerPool(),
+            Deserialization.STRING,
+            Deserialization.STRING,
+            page_size=1,
+        )
+        service.on_assign(consumer, [TopicPartition("orders", 0)])
+
+        records = await service.consume()
+
+        self.assertEqual(1, len(records))
+        self.assertEqual("key", records[0].key_str())
+        consumer.consume.assert_called_once_with(1, timeout=service.timeout)
 
 
 if __name__ == "__main__":

--- a/tests/tests_themes.py
+++ b/tests/tests_themes.py
@@ -43,6 +43,7 @@ from kaskade.themes import (
     available_theme_names,
 )
 from kaskade.widgets import KaskadeOptionList, KaskadeScrollableContainer, StretchyDataTable
+from tests import configure_admin_service
 
 
 class TestThemes(unittest.TestCase):
@@ -139,11 +140,12 @@ class TestThemes(unittest.TestCase):
 class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
     async def test_uses_footer_and_opens_a_keyboard_navigable_help_window(self):
         with patch("kaskade.admin.TopicService") as topic_service:
-            topic_service.return_value.all = AsyncMock(
-                return_value={
+            configure_admin_service(
+                topic_service.return_value,
+                {
                     "orders": Topic(name="orders"),
                     "payments": Topic(name="payments"),
-                }
+                },
             )
             app = KaskadeAdmin({})
 
@@ -232,12 +234,13 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
 
     async def test_admin_supports_vim_navigation(self):
         with patch("kaskade.admin.TopicService") as topic_service:
-            topic_service.return_value.all = AsyncMock(
-                return_value={
+            configure_admin_service(
+                topic_service.return_value,
+                {
                     "alpha": Topic(name="alpha"),
                     "bravo": Topic(name="bravo"),
                     "charlie": Topic(name="charlie"),
-                }
+                },
             )
             app = KaskadeAdmin({})
 
@@ -257,7 +260,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
 
     async def test_plain_shortcuts_do_not_intercept_filter_input(self):
         with patch("kaskade.admin.TopicService") as topic_service:
-            topic_service.return_value.all = AsyncMock(return_value={})
+            configure_admin_service(topic_service.return_value, {})
             app = KaskadeAdmin({})
 
             async with app.run_test() as pilot:
@@ -281,7 +284,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
 
     async def test_modal_footers_show_and_run_implicit_submit_actions(self):
         with patch("kaskade.admin.TopicService") as topic_service:
-            topic_service.return_value.all = AsyncMock(return_value={})
+            configure_admin_service(topic_service.return_value, {})
             app = KaskadeAdmin({})
             results: list[object] = []
 
@@ -332,8 +335,9 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
 
     async def test_admin_uses_title_case_labels_and_contextual_palette_commands(self):
         with patch("kaskade.admin.TopicService") as topic_service:
-            topic_service.return_value.all = AsyncMock(
-                return_value={"orders": Topic(name="orders")}
+            configure_admin_service(
+                topic_service.return_value,
+                {"orders": Topic(name="orders")},
             )
             app = KaskadeAdmin({})
 
@@ -427,7 +431,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
 
     async def test_topic_details_use_native_tabs_and_a_contextual_footer(self):
         with patch("kaskade.admin.TopicService") as topic_service:
-            topic_service.return_value.all = AsyncMock(return_value={})
+            configure_admin_service(topic_service.return_value, {})
             app = KaskadeAdmin({})
 
             async with app.run_test() as pilot:
@@ -464,7 +468,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
 
     async def test_chunk_size_uses_an_option_list_with_the_current_value_selected(self):
         with patch("kaskade.admin.TopicService") as topic_service:
-            topic_service.return_value.all = AsyncMock(return_value={})
+            configure_admin_service(topic_service.return_value, {})
             app = KaskadeAdmin({})
 
             async with app.run_test() as pilot:
@@ -483,7 +487,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
     async def test_renders_dark_light_and_ansi_themes(self):
         for theme in (DEFAULT_THEME, "textual-light", "ansi-light"):
             with self.subTest(theme=theme), patch("kaskade.admin.TopicService") as topic_service:
-                topic_service.return_value.all = AsyncMock(return_value={})
+                configure_admin_service(topic_service.return_value, {})
                 app = KaskadeAdmin({})
                 app.theme = theme
 


### PR DESCRIPTION
Improve Kafka data loading and keep Admin mode current without manual refreshes.

## Summary

- render topic metadata before asynchronously enriching record and consumer-group metrics
- replace per-partition consumers with two batched offset requests and bounded group-offset concurrency
- add configurable 30-second admin auto-refresh with modal pause/resume, stale-while-revalidate rows, and refresh coalescing
- support `admin --refresh-interval SECONDS` as a per-session override, with `0` disabling auto-refresh and enabled values requiring at least 5 seconds
- consume records in batches and cache successful deserialization results
- centralize refresh state so manual, resumed, and mutation refreshes coalesce without overlapping broker scans
- split settings, deserialization, consumer polling, Kafka mapping, refresh staging, and table rendering into focused helpers
- enforce a repository-wide cyclomatic complexity limit of 10 with Ruff `C901`
- document the new admin settings and cover progressive loading, concurrency, cancellation, stale snapshots, filter/selection preservation, CLI precedence, and failure states

## Verification

- `poetry run python -m scripts.analyze`
- `poetry run python -m scripts.tests`
- `poetry run python -m scripts.tests --e2e` with Kafka and Redpanda

Assisted-by: Codex GPT-5
