### PR TITLE
fix(ui): improve help command discovery

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -78,7 +78,8 @@ Kaskade follows familiar k9s/Vim-style terminal interactions where practical:
   text input.
 - Keep Textual's command palette on `:` with `ctrl+p` as an alternative. Expose
   contextual Kaskade actions in it, omit duplicate navigation actions, and do
-  not expose Textual maximize/minimize commands.
+  not expose Textual maximize/minimize commands. Replace Textual's generic Keys
+  command with Kaskade's contextual Help window.
 
 ### Footer command order
 
@@ -100,6 +101,8 @@ primary action.
 Help is a dedicated centered `ModalScreen`, not a sidebar. It must:
 
 - Snapshot the bindings of the screen beneath it and group them by context.
+- Show every effective shortcut alias for each action while leaving compact
+  Footer key displays unchanged.
 - Put keyboard focus on its command table so arrows and page navigation work
   without a mouse, then restore the previous focus when it closes.
 - Use the contextual border title `Help — <Context>`.

--- a/USAGE.md
+++ b/USAGE.md
@@ -73,7 +73,7 @@ Kaskade supports arrow keys and Vim-style navigation. The defaults follow famili
 | Consume more records | `n` |
 | Change record chunk size | `#` |
 
-Help opens in a contextual window above the current screen. Navigate it with `j`/`k`, arrows, Page Up/Down, or `g`/`G`, then close it with `Esc`, `q`, `?`, or `F1`.
+Help opens in a contextual window above the current screen and lists every effective shortcut alias. Navigate it with `j`/`k`, arrows, Page Up/Down, or `g`/`G`, then close it with `Esc`, `q`, `?`, or `F1`. The command palette includes this contextual Help window instead of Textual's generic Keys panel.
 
 Plain-character application shortcuts do not intercept typing in filter and editor fields.
 

--- a/kaskade/help.py
+++ b/kaskade/help.py
@@ -48,15 +48,42 @@ def contextual_help(screen: Screen) -> tuple[str, tuple[HelpBinding, ...]]:
                 binding.description,
             )
         keys = groups[group_key][1]
-        key_display = screen.app.get_key_display(binding)
-        if key_display not in keys:
-            keys.append(key_display)
+        for alias in _binding_aliases(screen, namespace, binding):
+            key_display = screen.app.get_key_display(alias)
+            if key_display in keys:
+                key_display = screen.app.get_key_display(
+                    alias.with_key(alias.key, key_display=None)
+                )
+            if key_display not in keys:
+                keys.append(key_display)
 
     bindings = tuple(
         HelpBinding(context, tuple(keys), description)
         for context, keys, description in groups.values()
     )
     return _focused_context(screen), bindings
+
+
+def _binding_aliases(screen: Screen, namespace: object, binding: Binding) -> tuple[Binding, ...]:
+    """Return every effective alias owned by the binding's namespace."""
+    settings = getattr(screen.app, "keymap_settings", None)
+    configured_keys = getattr(settings, "keymap", {}).get(binding.id)
+    if configured_keys:
+        return tuple(
+            binding.with_key(key.strip(), key_display=None) for key in configured_keys.split(",")
+        )
+
+    bindings_map = getattr(namespace, "_bindings", None)
+    if bindings_map is None:
+        return (binding,)
+
+    aliases = tuple(
+        candidate
+        for candidates in bindings_map.key_to_bindings.values()
+        for candidate in candidates
+        if candidate.action == binding.action and candidate.id == binding.id
+    )
+    return aliases or (binding,)
 
 
 def _binding_context(namespace: object) -> str:

--- a/kaskade/themes.py
+++ b/kaskade/themes.py
@@ -9,7 +9,7 @@ from textual.binding import Binding, BindingType
 from textual.screen import Screen
 from textual.theme import BUILTIN_THEMES, Theme
 
-from kaskade.help import HelpScreen, contextual_help
+from kaskade.help import HELP_BINDING, HelpScreen, contextual_help
 from kaskade.keymaps import NAVIGATION_BINDING_IDS, load_settings
 
 DEFAULT_THEME = "eva01"
@@ -110,8 +110,15 @@ class KaskadeApp(App, inherit_bindings=False):
     def get_system_commands(self, screen: Screen) -> Iterable[SystemCommand]:
         """Add active Kaskade bindings to Textual's command palette."""
         widget_size_actions = (screen.action_maximize, screen.action_minimize)
+        help_panel_actions = (self.action_show_help_panel, self.action_hide_help_panel)
         for command in super().get_system_commands(screen):
-            if command.callback not in widget_size_actions:
+            if command.callback in help_panel_actions:
+                yield SystemCommand(
+                    HELP_BINDING.description,
+                    HELP_BINDING.tooltip,
+                    self.action_toggle_help,
+                )
+            elif command.callback not in widget_size_actions:
                 yield command
 
         command_ids: set[str] = set()

--- a/tests/tests_keymaps.py
+++ b/tests/tests_keymaps.py
@@ -229,16 +229,23 @@ class TestConfiguredKeymap(unittest.IsolatedAsyncioTestCase):
     async def test_app_applies_configured_keymap(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             path = Path(temporary_directory) / "config.yaml"
-            path.write_text("keymap:\n  help.toggle: x\n", encoding="utf-8")
+            path.write_text("keymap:\n  help.toggle: x,y\n", encoding="utf-8")
             app = KaskadeApp(keymap_path=path)
 
             async with app.run_test() as pilot:
                 await pilot.press("x")
 
                 self.assertIsInstance(app.screen, HelpScreen)
+                help_binding = next(
+                    binding for binding in app.screen.help_bindings if binding.description == "Help"
+                )
+                self.assertEqual(("x", "y"), help_binding.keys)
 
                 await pilot.press("x")
                 self.assertNotIsInstance(app.screen, HelpScreen)
+
+                await pilot.press("y")
+                self.assertIsInstance(app.screen, HelpScreen)
 
     async def test_app_applies_navigation_override_to_child_widgets(self):
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/tests_themes.py
+++ b/tests/tests_themes.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import AsyncMock, patch
 
-from textual.command import CommandPalette
+from textual.command import CommandList, CommandPalette
 from textual.containers import ScrollableContainer
 from textual.theme import BUILTIN_THEMES, ThemeProvider
 from textual.widgets import (
@@ -209,6 +209,12 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                     if binding.description == "Quit"
                 )
                 self.assertEqual(("ctrl+c",), quit_binding.keys)
+                binding_keys = {
+                    binding.description: binding.keys for binding in help_screen.help_bindings
+                }
+                self.assertEqual(("?", "f1"), binding_keys["Help"])
+                self.assertEqual((":", "^p"), binding_keys["Commands"])
+                self.assertEqual(("d", "⏎"), binding_keys["Describe"])
                 await pilot.press("pagedown")
                 await pilot.pause()
                 self.assertGreater(help_table.cursor_row, 0)
@@ -231,6 +237,20 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 await pilot.resize_terminal(120, 30)
                 await pilot.pause()
                 self.assertEqual(72, palette_input.region.width)
+
+                palette_input.value = "help"
+                await pilot.pause()
+                command_list = app.screen.query_one(CommandList)
+                command_list.highlighted = next(
+                    index
+                    for index in range(command_list.option_count)
+                    if command_list.get_option_at_index(index).hit.text == "Help"
+                )
+                await pilot.press("enter")
+                await pilot.pause()
+
+                self.assertIsInstance(app.screen, HelpScreen)
+                self.assertEqual("Topics", app.screen.context)
 
     async def test_admin_supports_vim_navigation(self):
         with patch("kaskade.admin.TopicService") as topic_service:
@@ -364,8 +384,19 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 self.assertFalse(table.show_horizontal_scrollbar)
                 self.assertIn("Topics", table.border_title)
                 self.assertTrue(
-                    {"Theme", "Describe", "Filter", "Refresh", "Create"} <= command_titles
+                    {
+                        "Theme",
+                        "Quit",
+                        "Help",
+                        "Screenshot",
+                        "Describe",
+                        "Filter",
+                        "Refresh",
+                        "Create",
+                    }
+                    <= command_titles
                 )
+                self.assertNotIn("Keys", command_titles)
                 self.assertTrue({"Maximize", "Minimize"}.isdisjoint(command_titles))
 
                 app.screen.action_maximize()


### PR DESCRIPTION
## Summary
- show every effective shortcut alias in contextual Help while preserving compact footer labels
- replace Textual's Keys palette command with Kaskade's contextual Help window
- document the updated Help and command-palette behavior

## Testing
- poetry run python -m scripts.analyze
- poetry run python -m scripts.tests
- poetry run python -m scripts.tests --e2e