### PR TITLE
feat(ui): add main view header

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -118,6 +118,9 @@ Help is a dedicated centered `ModalScreen`, not a sidebar. It must:
 
 - Keep all application styling in the shared `kaskade/styles.css`; both admin
   and consumer applications inherit `KaskadeApp.CSS_PATH`.
+- Keep the shared one-line root header on both main applications: show the
+  Kaskade version on the left and only Kafka `bootstrap.servers` on the right.
+  Truncate the Kafka text before allowing the version to disappear.
 - Use Title Case for screen titles, border titles, table headings, tabs, command
   labels, and field labels.
 - Follow the existing centered-modal vocabulary: one visible outer border,

--- a/AGENT.md
+++ b/AGENT.md
@@ -120,8 +120,10 @@ Help is a dedicated centered `ModalScreen`, not a sidebar. It must:
   and consumer applications inherit `KaskadeApp.CSS_PATH`.
 - Keep the shared one-line root header on both main applications: show the
   Kaskade version on the left and only Kafka `bootstrap.servers` on the right.
-  Truncate the Kafka text before allowing the version to disappear. Leave one
-  row around the header and one column on each side of the complete root view.
+  Give the name and version contrasting semantic colors, and truncate the Kafka
+  text before allowing the version to disappear. Pad the header by one row in
+  the shared panel background and leave one column on each side of the complete
+  root view.
 - Use Title Case for screen titles, border titles, table headings, tabs, command
   labels, and field labels.
 - Follow the existing centered-modal vocabulary: one visible outer border,

--- a/AGENT.md
+++ b/AGENT.md
@@ -138,9 +138,10 @@ Help is a dedicated centered `ModalScreen`, not a sidebar. It must:
   outer `TabbedContent`. Do not add borders or border titles to the tables inside
   the tabs. Put collection counts in tab labels, for example
   `Partitions [50]`.
-- Tables used as primary screens retain Kaskade's focus-aware border. Detail
-  tables embedded inside another bordered component use the borderless
-  `details-table` style.
+- Keep table backgrounds transparent so they inherit each window's background.
+  Primary tables retain transparent border geometry, while detail tables
+  embedded inside another bordered component use the borderless `details-table`
+  style.
 
 ## Themes
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -120,7 +120,8 @@ Help is a dedicated centered `ModalScreen`, not a sidebar. It must:
   and consumer applications inherit `KaskadeApp.CSS_PATH`.
 - Keep the shared one-line root header on both main applications: show the
   Kaskade version on the left and only Kafka `bootstrap.servers` on the right.
-  Truncate the Kafka text before allowing the version to disappear.
+  Truncate the Kafka text before allowing the version to disappear. Leave one
+  row around the header and one column on each side of the complete root view.
 - Use Title Case for screen titles, border titles, table headings, tabs, command
   labels, and field labels.
 - Follow the existing centered-modal vocabulary: one visible outer border,

--- a/AGENT.md
+++ b/AGENT.md
@@ -139,9 +139,9 @@ Help is a dedicated centered `ModalScreen`, not a sidebar. It must:
   the tabs. Put collection counts in tab labels, for example
   `Partitions [50]`.
 - Keep table backgrounds transparent so they inherit each window's background.
-  Primary tables retain transparent border geometry, while detail tables
-  embedded inside another bordered component use the borderless `details-table`
-  style.
+  Primary tables retain Kaskade's visible focus-aware border, while detail
+  tables embedded inside another bordered component use the borderless
+  `details-table` style.
 
 ## Themes
 

--- a/kaskade/admin.py
+++ b/kaskade/admin.py
@@ -41,7 +41,7 @@ from kaskade.services import (
 from kaskade.themes import KaskadeApp
 from kaskade.unicodes import APPROXIMATION
 from kaskade.utils import make_it_async, notify_error
-from kaskade.widgets import StretchyDataTable
+from kaskade.widgets import KaskadeHeader, StretchyDataTable
 
 REFRESH_TABLE_DELAY = 1
 FILTER_TOPICS_SHORTCUT = "/,ctrl+f"
@@ -1150,5 +1150,6 @@ class KaskadeAdmin(KaskadeApp):
             self._auto_refresh_timer.reset()
 
     def compose(self) -> ComposeResult:
+        yield KaskadeHeader(self.kafka_config)
         yield ListTopics(TopicService(self.kafka_config))
         yield Footer(compact=True)

--- a/kaskade/consumer.py
+++ b/kaskade/consumer.py
@@ -19,7 +19,12 @@ from kaskade.models import Record
 from kaskade.services import ConsumerService
 from kaskade.themes import KaskadeApp
 from kaskade.utils import notify_error
-from kaskade.widgets import KaskadeOptionList, KaskadeScrollableContainer, StretchyDataTable
+from kaskade.widgets import (
+    KaskadeHeader,
+    KaskadeOptionList,
+    KaskadeScrollableContainer,
+    StretchyDataTable,
+)
 
 CHUNKS_SHORTCUT = "#"
 NEXT_SHORTCUT = "n"
@@ -454,6 +459,7 @@ class KaskadeConsumer(KaskadeApp):
         self.value_deserialization = value_deserialization
 
     def compose(self) -> ComposeResult:
+        yield KaskadeHeader(self.kafka_config)
         yield ListRecords(
             self.topic,
             self.kafka_config,

--- a/kaskade/styles.css
+++ b/kaskade/styles.css
@@ -25,13 +25,17 @@ KaskadeHeader > #kaskade-kafka {
     text-wrap: nowrap;
 }
 
+DataTable {
+    background: transparent;
+}
+
 DataTable.kaskade-table {
-    border: solid $secondary 50%;
+    border: solid transparent;
     height: 100%;
 }
 
 DataTable.kaskade-table:focus {
-    border: $secondary;
+    border: solid transparent;
 }
 
 DataTable.details-table {

--- a/kaskade/styles.css
+++ b/kaskade/styles.css
@@ -1,19 +1,19 @@
 Screen.main-view-screen {
     padding: 0 1;
+    background: $panel;
 }
 
 KaskadeHeader {
     dock: top;
     width: 100%;
-    height: 1;
-    margin: 1 0;
+    height: 3;
+    padding: 1 0;
     background: $panel;
     color: $foreground;
 }
 
 KaskadeHeader > #kaskade-product {
     width: auto;
-    color: $primary;
     text-style: bold;
 }
 

--- a/kaskade/styles.css
+++ b/kaskade/styles.css
@@ -1,3 +1,26 @@
+KaskadeHeader {
+    dock: top;
+    width: 100%;
+    height: 1;
+    background: $panel;
+    color: $foreground;
+}
+
+KaskadeHeader > #kaskade-product {
+    width: auto;
+    padding: 0 1;
+    text-style: bold;
+}
+
+KaskadeHeader > #kaskade-kafka {
+    width: 1fr;
+    padding: 0 1;
+    color: $text-muted;
+    text-align: right;
+    text-overflow: ellipsis;
+    text-wrap: nowrap;
+}
+
 DataTable.kaskade-table {
     border: solid $secondary 50%;
     height: 100%;

--- a/kaskade/styles.css
+++ b/kaskade/styles.css
@@ -1,8 +1,12 @@
+Screen.main-view-screen {
+    padding: 0 1;
+}
+
 KaskadeHeader {
     dock: top;
     width: 100%;
     height: 1;
-    padding: 0 1;
+    margin: 1 0;
     background: $panel;
     color: $foreground;
 }

--- a/kaskade/styles.css
+++ b/kaskade/styles.css
@@ -2,19 +2,19 @@ KaskadeHeader {
     dock: top;
     width: 100%;
     height: 1;
+    padding: 0 1;
     background: $panel;
     color: $foreground;
 }
 
 KaskadeHeader > #kaskade-product {
     width: auto;
-    padding: 0 1;
+    color: $primary;
     text-style: bold;
 }
 
 KaskadeHeader > #kaskade-kafka {
     width: 1fr;
-    padding: 0 1;
     color: $text-muted;
     text-align: right;
     text-overflow: ellipsis;

--- a/kaskade/styles.css
+++ b/kaskade/styles.css
@@ -30,12 +30,12 @@ DataTable {
 }
 
 DataTable.kaskade-table {
-    border: solid transparent;
+    border: solid $secondary 50%;
     height: 100%;
 }
 
 DataTable.kaskade-table:focus {
-    border: solid transparent;
+    border: $secondary;
 }
 
 DataTable.details-table {

--- a/kaskade/themes.py
+++ b/kaskade/themes.py
@@ -92,6 +92,7 @@ class KaskadeApp(App, inherit_bindings=False):
         self._sync_rich_theme()
 
     def on_mount(self) -> None:
+        self.screen.add_class("main-view-screen")
         for warning_message in self.keymap_settings.warnings:
             self.notify(
                 warning_message,

--- a/kaskade/widgets.py
+++ b/kaskade/widgets.py
@@ -1,7 +1,7 @@
 from collections.abc import Mapping
 from typing import Any, ClassVar
 
-from rich.text import TextType
+from rich.text import Text, TextType
 from textual import events
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
@@ -23,8 +23,11 @@ class KaskadeHeader(Horizontal):
         self.bootstrap_servers = str(bootstrap_servers)
 
     def compose(self) -> ComposeResult:
+        product = Text()
+        product.append(APP_NAME.title(), style="primary")
+        product.append(f" v{APP_VERSION}", style="secondary")
         yield Static(
-            f"{APP_NAME.title()} v{APP_VERSION}",
+            product,
             id="kaskade-product",
             markup=False,
         )

--- a/kaskade/widgets.py
+++ b/kaskade/widgets.py
@@ -20,7 +20,7 @@ class KaskadeHeader(Horizontal):
     def __init__(self, kafka_config: Mapping[str, Any]) -> None:
         super().__init__(id="kaskade-header")
         bootstrap_servers = kafka_config.get(BOOTSTRAP_SERVERS, "Not configured")
-        self.kafka_information = f"Kafka: {bootstrap_servers}"
+        self.bootstrap_servers = str(bootstrap_servers)
 
     def compose(self) -> ComposeResult:
         yield Static(
@@ -29,7 +29,7 @@ class KaskadeHeader(Horizontal):
             markup=False,
         )
         yield Static(
-            self.kafka_information,
+            self.bootstrap_servers,
             id="kaskade-kafka",
             markup=False,
         )

--- a/kaskade/widgets.py
+++ b/kaskade/widgets.py
@@ -1,12 +1,38 @@
+from collections.abc import Mapping
 from typing import Any, ClassVar
 
 from rich.text import TextType
 from textual import events
+from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
-from textual.containers import ScrollableContainer
+from textual.containers import Horizontal, ScrollableContainer
 from textual.geometry import Size
-from textual.widgets import DataTable, OptionList
+from textual.widgets import DataTable, OptionList, Static
 from textual.widgets.data_table import CellType, ColumnKey
+
+from kaskade import APP_NAME, APP_VERSION
+from kaskade.configs import BOOTSTRAP_SERVERS
+
+
+class KaskadeHeader(Horizontal):
+    """Display the application version and active Kafka bootstrap servers."""
+
+    def __init__(self, kafka_config: Mapping[str, Any]) -> None:
+        super().__init__(id="kaskade-header")
+        bootstrap_servers = kafka_config.get(BOOTSTRAP_SERVERS, "Not configured")
+        self.kafka_information = f"Kafka: {bootstrap_servers}"
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            f"{APP_NAME.title()} v{APP_VERSION}",
+            id="kaskade-product",
+            markup=False,
+        )
+        yield Static(
+            self.kafka_information,
+            id="kaskade-kafka",
+            markup=False,
+        )
 
 
 class StretchyDataTable(DataTable[CellType]):

--- a/tests/tests_themes.py
+++ b/tests/tests_themes.py
@@ -165,21 +165,28 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                     binding.description for _, binding, _, _ in app.screen.active_bindings.values()
                 }
 
-                self.assertEqual(f"Kaskade v{APP_VERSION}", product.render().plain)
+                product_text = product.render()
+                self.assertEqual(f"Kaskade v{APP_VERSION}", product_text.plain)
+                self.assertEqual(
+                    [app.current_theme.primary, app.current_theme.secondary],
+                    [span.style.foreground.hex for span in product_text.spans],
+                )
                 self.assertEqual("Not configured", kafka.render().plain)
                 self.assertTrue(app.screen.has_class("main-view-screen"))
                 self.assertEqual(1, app.screen.styles.padding.left)
                 self.assertEqual(1, app.screen.styles.padding.right)
-                self.assertEqual(1, header.styles.margin.top)
-                self.assertEqual(1, header.styles.margin.bottom)
-                self.assertEqual(app.current_theme.primary, product.styles.color.hex)
+                self.assertEqual(1, header.styles.padding.top)
+                self.assertEqual(1, header.styles.padding.bottom)
+                self.assertEqual(app.current_theme.panel, header.styles.background.hex)
+                self.assertEqual(header.styles.background, app.screen.styles.background)
                 footer = app.query_one(Footer)
                 self.assertIsInstance(footer, Footer)
                 for widget in (header, table, footer):
                     self.assertEqual(1, widget.region.x)
                     self.assertEqual(app.screen.region.right - 1, widget.region.right)
-                self.assertEqual(1, header.region.y)
-                self.assertEqual(header.region.bottom + 1, table.region.y)
+                self.assertEqual(0, header.region.y)
+                self.assertEqual(1, header.content_region.y)
+                self.assertEqual(header.region.bottom, table.region.y)
                 self.assertIs(table, app.screen.focused)
                 self.assertTrue(
                     {"Describe", "Filter", "Refresh", "Create", "Quit", "Commands"}
@@ -484,7 +491,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
 
                 self.assertEqual(f"Kaskade v{APP_VERSION}", product.render().plain)
                 self.assertEqual(bootstrap_servers, kafka.render().plain)
-                self.assertEqual(1, header.region.height)
+                self.assertEqual(3, header.region.height)
                 self.assertEqual(app.screen.content_region.width, header.region.width)
                 self.assertEqual(
                     header.content_region.width,

--- a/tests/tests_themes.py
+++ b/tests/tests_themes.py
@@ -26,6 +26,7 @@ from kaskade.admin import (
     KaskadeAdmin,
     ListTopics,
 )
+from kaskade.configs import BOOTSTRAP_SERVERS
 from kaskade.consumer import (
     ChunkSizeScreen,
     FilterRecordScreen,
@@ -42,7 +43,12 @@ from kaskade.themes import (
     KaskadeApp,
     available_theme_names,
 )
-from kaskade.widgets import KaskadeOptionList, KaskadeScrollableContainer, StretchyDataTable
+from kaskade.widgets import (
+    KaskadeHeader,
+    KaskadeOptionList,
+    KaskadeScrollableContainer,
+    StretchyDataTable,
+)
 from tests import configure_admin_service
 
 
@@ -152,10 +158,15 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
             async with app.run_test(size=(70, 18)) as pilot:
                 await pilot.pause()
                 table = app.query_one("#topics-table", DataTable)
+                header = app.query_one(KaskadeHeader)
+                product = header.query_one("#kaskade-product", Static)
+                kafka = header.query_one("#kaskade-kafka", Static)
                 active_descriptions = {
                     binding.description for _, binding, _, _ in app.screen.active_bindings.values()
                 }
 
+                self.assertEqual(f"Kaskade v{APP_VERSION}", product.render().plain)
+                self.assertEqual("Kafka: Not configured", kafka.render().plain)
                 self.assertIsInstance(app.query_one(Footer), Footer)
                 self.assertIs(table, app.screen.focused)
                 self.assertTrue(
@@ -411,9 +422,10 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
     async def test_consumer_uses_a_stretchy_records_table(self):
         with patch("kaskade.consumer.ConsumerService") as consumer_service:
             consumer_service.return_value.consume = AsyncMock(return_value=[])
+            bootstrap_servers = "kafka1:9092,kafka2:9092"
             app = KaskadeConsumer(
                 "orders",
-                {},
+                {BOOTSTRAP_SERVERS: bootstrap_servers},
                 {},
                 {},
                 {},
@@ -424,8 +436,18 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
             async with app.run_test(size=(80, 24)) as pilot:
                 await pilot.pause()
                 table = app.query_one("#records-table", DataTable)
+                header = app.query_one(KaskadeHeader)
 
+                self.assertEqual(
+                    f"Kaskade v{APP_VERSION}",
+                    header.query_one("#kaskade-product", Static).render().plain,
+                )
+                self.assertEqual(
+                    f"Kafka: {bootstrap_servers}",
+                    header.query_one("#kaskade-kafka", Static).render().plain,
+                )
                 self.assertIsInstance(table, StretchyDataTable)
+                self.assertIs(table, app.screen.focused)
                 self.assertEqual(
                     ["Key", "Value", "Timestamp", "Partition", "Offset", "Headers"],
                     [column.label.plain for column in table.ordered_columns],
@@ -435,6 +457,26 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                     [column.width for column in table.ordered_columns[2:]],
                 )
                 self.assertFalse(table.show_horizontal_scrollbar)
+
+    async def test_header_constrains_kafka_information_on_narrow_terminals(self):
+        bootstrap_servers = "[::1]:9092,kafka2.example.com:9092"
+        with patch("kaskade.admin.TopicService") as topic_service:
+            configure_admin_service(topic_service.return_value, {})
+            app = KaskadeAdmin({BOOTSTRAP_SERVERS: bootstrap_servers})
+
+            async with app.run_test(size=(24, 18)) as pilot:
+                await pilot.pause()
+                header = app.query_one(KaskadeHeader)
+                product = header.query_one("#kaskade-product", Static)
+                kafka = header.query_one("#kaskade-kafka", Static)
+
+                self.assertEqual(f"Kaskade v{APP_VERSION}", product.render().plain)
+                self.assertEqual(f"Kafka: {bootstrap_servers}", kafka.render().plain)
+                self.assertEqual(1, header.region.height)
+                self.assertEqual(app.screen.size.width, header.region.width)
+                self.assertEqual(header.region.width, product.region.width + kafka.region.width)
+                self.assertLess(kafka.content_region.width, len(kafka.render().plain))
+                self.assertEqual("ellipsis", kafka.styles.text_overflow)
 
     async def test_record_details_focus_the_scrollable_content(self):
         with patch("kaskade.consumer.ConsumerService") as consumer_service:

--- a/tests/tests_themes.py
+++ b/tests/tests_themes.py
@@ -179,6 +179,8 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(1, header.styles.padding.bottom)
                 self.assertEqual(app.current_theme.panel, header.styles.background.hex)
                 self.assertEqual(header.styles.background, app.screen.styles.background)
+                self.assertEqual(0, table.styles.background.a)
+                self.assertEqual(0, table.styles.border_top[1].a)
                 footer = app.query_one(Footer)
                 self.assertIsInstance(footer, Footer)
                 for widget in (header, table, footer):
@@ -552,6 +554,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 for table in detail_tables:
                     self.assertIsNone(table.border_title)
                     self.assertEqual("", table.styles.border_top[0])
+                    self.assertEqual(0, table.styles.background.a)
                 self.assertGreater(partitions.content_region.height, 0)
                 self.assertFalse(partitions.show_horizontal_scrollbar)
                 self.assertIsInstance(app.screen.query_one(Footer), Footer)

--- a/tests/tests_themes.py
+++ b/tests/tests_themes.py
@@ -166,7 +166,10 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 }
 
                 self.assertEqual(f"Kaskade v{APP_VERSION}", product.render().plain)
-                self.assertEqual("Kafka: Not configured", kafka.render().plain)
+                self.assertEqual("Not configured", kafka.render().plain)
+                self.assertEqual(1, header.styles.padding.left)
+                self.assertEqual(1, header.styles.padding.right)
+                self.assertEqual(app.current_theme.primary, product.styles.color.hex)
                 self.assertIsInstance(app.query_one(Footer), Footer)
                 self.assertIs(table, app.screen.focused)
                 self.assertTrue(
@@ -443,7 +446,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                     header.query_one("#kaskade-product", Static).render().plain,
                 )
                 self.assertEqual(
-                    f"Kafka: {bootstrap_servers}",
+                    bootstrap_servers,
                     header.query_one("#kaskade-kafka", Static).render().plain,
                 )
                 self.assertIsInstance(table, StretchyDataTable)
@@ -471,10 +474,13 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 kafka = header.query_one("#kaskade-kafka", Static)
 
                 self.assertEqual(f"Kaskade v{APP_VERSION}", product.render().plain)
-                self.assertEqual(f"Kafka: {bootstrap_servers}", kafka.render().plain)
+                self.assertEqual(bootstrap_servers, kafka.render().plain)
                 self.assertEqual(1, header.region.height)
                 self.assertEqual(app.screen.size.width, header.region.width)
-                self.assertEqual(header.region.width, product.region.width + kafka.region.width)
+                self.assertEqual(
+                    header.content_region.width,
+                    product.region.width + kafka.region.width,
+                )
                 self.assertLess(kafka.content_region.width, len(kafka.render().plain))
                 self.assertEqual("ellipsis", kafka.styles.text_overflow)
 

--- a/tests/tests_themes.py
+++ b/tests/tests_themes.py
@@ -180,7 +180,8 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(app.current_theme.panel, header.styles.background.hex)
                 self.assertEqual(header.styles.background, app.screen.styles.background)
                 self.assertEqual(0, table.styles.background.a)
-                self.assertEqual(0, table.styles.border_top[1].a)
+                self.assertNotEqual("", table.styles.border_top[0])
+                self.assertGreater(table.styles.border_top[1].a, 0)
                 footer = app.query_one(Footer)
                 self.assertIsInstance(footer, Footer)
                 for widget in (header, table, footer):

--- a/tests/tests_themes.py
+++ b/tests/tests_themes.py
@@ -167,10 +167,19 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
 
                 self.assertEqual(f"Kaskade v{APP_VERSION}", product.render().plain)
                 self.assertEqual("Not configured", kafka.render().plain)
-                self.assertEqual(1, header.styles.padding.left)
-                self.assertEqual(1, header.styles.padding.right)
+                self.assertTrue(app.screen.has_class("main-view-screen"))
+                self.assertEqual(1, app.screen.styles.padding.left)
+                self.assertEqual(1, app.screen.styles.padding.right)
+                self.assertEqual(1, header.styles.margin.top)
+                self.assertEqual(1, header.styles.margin.bottom)
                 self.assertEqual(app.current_theme.primary, product.styles.color.hex)
-                self.assertIsInstance(app.query_one(Footer), Footer)
+                footer = app.query_one(Footer)
+                self.assertIsInstance(footer, Footer)
+                for widget in (header, table, footer):
+                    self.assertEqual(1, widget.region.x)
+                    self.assertEqual(app.screen.region.right - 1, widget.region.right)
+                self.assertEqual(1, header.region.y)
+                self.assertEqual(header.region.bottom + 1, table.region.y)
                 self.assertIs(table, app.screen.focused)
                 self.assertTrue(
                     {"Describe", "Filter", "Refresh", "Create", "Quit", "Commands"}
@@ -476,7 +485,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(f"Kaskade v{APP_VERSION}", product.render().plain)
                 self.assertEqual(bootstrap_servers, kafka.render().plain)
                 self.assertEqual(1, header.region.height)
-                self.assertEqual(app.screen.size.width, header.region.width)
+                self.assertEqual(app.screen.content_region.width, header.region.width)
                 self.assertEqual(
                     header.content_region.width,
                     product.region.width + kafka.region.width,


### PR DESCRIPTION
Add a shared root header to the Admin and Consumer views.

## Summary

- show the installed Kaskade version on the left
- show only the active Kafka bootstrap servers on the right
- preserve the version while truncating long broker lists on narrow terminals
- keep existing table focus, footer commands, mode labels, and modal layouts unchanged

## Verification

- poetry run python -m scripts.analyze
- poetry run python -m scripts.tests
- repository commit hooks, including e2e tests

Assisted-by: Codex GPT-5