### PR TITLE
feat(consumer): export records as json

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -124,6 +124,9 @@ Help is a dedicated centered `ModalScreen`, not a sidebar. It must:
   text before allowing the version to disappear. Pad the header by one row in
   the shared panel background and leave one column on each side of the complete
   root view.
+- Deliver consumed-record JSON exports through Textual's file-delivery API so
+  they use the same Downloads or browser destination as screenshots. Keep the
+  export available from both the records table and Record Details.
 - Use Title Case for screen titles, border titles, table headings, tabs, command
   labels, and field labels.
 - Follow the existing centered-modal vocabulary: one visible outer border,

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ It includes features like:
 
 - Json, string, integer, long, float, boolean and double deserialization.
 - Filter by key, value, header and/or partition.
+- Export individual consumed records as JSON.
 - Schema Registry support for avro and json.
 - Protobuf deserialization support without Schema Registry.
 - Avro deserialization without Schema Registry.
@@ -44,6 +45,10 @@ Kaskade does not include:
 ## Screenshots
 
 <table>
+  <tr>
+    <th>Admin</th>
+    <th>Consumer</th>
+  </tr>
   <tr>
     <td>
       <img alt="Kaskade admin mode" src="https://raw.githubusercontent.com/sauljabin/kaskade/main/images/admin.svg">

--- a/USAGE.md
+++ b/USAGE.md
@@ -70,6 +70,7 @@ Kaskade supports arrow keys and Vim-style navigation. The defaults follow famili
 | Edit a topic | `e` or `Ctrl+E` |
 | Delete a topic | `Ctrl+D` |
 | Refresh topics | `Ctrl+R` |
+| Export selected record | `Ctrl+E` |
 | Consume more records | `n` |
 | Change record chunk size | `#` |
 
@@ -107,11 +108,19 @@ Common configurable binding IDs are:
 | Application | `app.quit`, `app.command-palette`, `help.toggle`, `kaskade.help.close` |
 | Navigation | `kaskade.navigation.up`, `.down`, `.left`, `.right`, `.first`, `.last`, `.page-up`, `.page-down`, `.select` |
 | Topics | `kaskade.topics.describe`, `.filter`, `.refresh`, `.create`, `.edit`, `.delete`, `.show-all` |
-| Records | `kaskade.records.show`, `.consume`, `.filter`, `.chunk-size`, `.show-all` |
+| Records | `kaskade.records.show`, `.export`, `.consume`, `.filter`, `.chunk-size`, `.show-all` |
 | Dialogs | `kaskade.filter-topics.apply`, `kaskade.delete-topic.confirm`, `kaskade.filter-records.apply`, `kaskade.chunk-size.select` |
 | Editors | `kaskade.create-topic.save`, `kaskade.edit-topic.save` |
 
 Unknown binding IDs, invalid key names, and malformed configuration produce an in-app warning while Kaskade continues with its default bindings.
+
+### Export a consumed record
+
+Select a record in consumer mode or open its details, then press `Ctrl+E` to export it as
+JSON. Kaskade saves the file to the same destination as the Screenshot command: the
+Downloads directory in a local terminal or a browser download when web-hosted. The export
+includes the topic, partition, offset, date, headers, and the deserialized key and value with
+their deserializer names.
 
 ### Consume from the beginning
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -37,6 +37,7 @@ keymap:
 
   # Records
   kaskade.records.show: enter
+  kaskade.records.export: ctrl+e
   kaskade.records.consume: n
   kaskade.records.filter: slash,ctrl+f
   kaskade.records.chunk-size: "#"

--- a/kaskade/consumer.py
+++ b/kaskade/consumer.py
@@ -1,8 +1,11 @@
-from typing import Any, ClassVar
+import json
+from datetime import datetime, timezone
+from io import StringIO
+from typing import ClassVar
 
 from confluent_kafka import KafkaException
 from textual import work
-from textual.app import ComposeResult
+from textual.app import App, ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Container
 from textual.widgets import DataTable, Footer, Input, OptionList, Pretty
@@ -31,10 +34,37 @@ NEXT_SHORTCUT = "n"
 SUBMIT_SHORTCUT = "enter"
 BACK_SHORTCUT = "escape"
 FILTER_SHORTCUT = "/,ctrl+f"
+EXPORT_SHORTCUT = "ctrl+e"
 CONSUMER_EXCEPTIONS: tuple[type[Exception], ...] = (
     KafkaException,
     *DESERIALIZATION_EXCEPTIONS,
 )
+
+
+def record_json(record: Record) -> str:
+    """Return a readable JSON representation of a consumed record."""
+    return json.dumps(record.dict(), indent=2, ensure_ascii=False, default=str) + "\n"
+
+
+def record_filename(record: Record, exported_at: datetime | None = None) -> str:
+    """Build a screenshot-style, collision-resistant record export filename."""
+    export_time = exported_at or datetime.now(timezone.utc).astimezone()
+    timestamp = export_time.replace(tzinfo=None).isoformat()
+    filename_stem = f"kaskade-record-{record.topic}-{record.partition}-{record.offset}_{timestamp}"
+    for reserved_character in ' <>:"/\\|?*.':
+        filename_stem = filename_stem.replace(reserved_character, "_")
+    return f"{filename_stem}.json"
+
+
+def deliver_record(application: App[object], record: Record) -> None:
+    """Deliver a record to the same destination used by Textual screenshots."""
+    application.deliver_text(
+        StringIO(record_json(record)),
+        save_filename=record_filename(record),
+        encoding="utf-8",
+        mime_type="application/json",
+        name="record",
+    )
 
 
 class FilterRecordScreen(HelpableModalScreen[tuple[str, str, str, str]]):
@@ -178,30 +208,41 @@ class TopicScreen(HelpableModalScreen):
     AUTO_FOCUS = ".record-details"
     BINDINGS: ClassVar[list[BindingType]] = modal_bindings(
         Binding(
+            EXPORT_SHORTCUT,
+            "export_record",
+            "Export Record",
+            tooltip="Export the record as a JSON file.",
+            id="kaskade.records.export",
+        ),
+        Binding(
             BACK_SHORTCUT,
             "close",
             "Back",
             tooltip="Close the record details.",
             id="kaskade.record-details.close",
-        )
+        ),
     )
 
-    def __init__(self, topic: str, partition: int, offset: int, data: dict[str, Any]):
+    def __init__(self, record: Record):
         super().__init__()
-        self.data = data
-        self.topic = topic
-        self.partition = partition
-        self.record_offset = offset
+        self.record = record
+        self.data = record.dict()
 
     def compose(self) -> ComposeResult:
         container = KaskadeScrollableContainer(classes="record-details")
-        container.border_title = rf"[{PRIMARY}]Record[/] \[[{PRIMARY}]{self.topic}[/]]\[[{PRIMARY}]{self.partition}[/]]\[[{PRIMARY}]{self.record_offset}[/]]"
+        container.border_title = rf"[{PRIMARY}]Record[/] \[[{PRIMARY}]{self.record.topic}[/]]\[[{PRIMARY}]{self.record.partition}[/]]\[[{PRIMARY}]{self.record.offset}[/]]"
         with container:
             yield Pretty(self.data)
         yield Footer(compact=True)
 
     def action_close(self) -> None:
         self.dismiss()
+
+    def action_export_record(self) -> None:
+        try:
+            deliver_record(self.app, self.record)
+        except DESERIALIZATION_EXCEPTIONS as ex:
+            notify_error(self.app, "Deserialization Error", ex)
 
 
 class ListRecords(Container):
@@ -214,6 +255,13 @@ class ListRecords(Container):
             priority=True,
             tooltip="Open the complete selected record.",
             id="kaskade.records.show",
+        ),
+        Binding(
+            EXPORT_SHORTCUT,
+            "export_record",
+            "Export Record",
+            tooltip="Export the selected record as a JSON file.",
+            id="kaskade.records.export",
         ),
         Binding(
             NEXT_SHORTCUT,
@@ -365,14 +413,15 @@ class ListRecords(Container):
         if self.current_record is None:
             return
         try:
-            self.app.push_screen(
-                TopicScreen(
-                    self.current_record.topic,
-                    self.current_record.partition,
-                    self.current_record.offset,
-                    self.current_record.dict(),
-                )
-            )
+            self.app.push_screen(TopicScreen(self.current_record))
+        except DESERIALIZATION_EXCEPTIONS as ex:
+            notify_error(self.app, "Deserialization Error", ex)
+
+    def action_export_record(self) -> None:
+        if self.current_record is None:
+            return
+        try:
+            deliver_record(self.app, self.current_record)
         except DESERIALIZATION_EXCEPTIONS as ex:
             notify_error(self.app, "Deserialization Error", ex)
 
@@ -384,7 +433,7 @@ class ListRecords(Container):
 
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
         """Disable contextual actions when their required state is unavailable."""
-        if action == "show_message":
+        if action in {"export_record", "show_message"}:
             return self.current_record is not None
         if action == "all":
             return not self._is_consuming and any(

--- a/kaskade/keymaps.py
+++ b/kaskade/keymaps.py
@@ -53,6 +53,7 @@ KNOWN_BINDING_IDS = (
             "kaskade.record-details.close",
             "kaskade.records.chunk-size",
             "kaskade.records.consume",
+            "kaskade.records.export",
             "kaskade.records.filter",
             "kaskade.records.show",
             "kaskade.records.show-all",

--- a/kaskade/models.py
+++ b/kaskade/models.py
@@ -404,10 +404,14 @@ class Record:
                 if self.headers is not None
                 else []
             ),
-            "key deserializer": self.key_deserialization.name,
-            "value deserializer": self.value_deserialization.name,
-            "key": self.key_deserialized(),
-            "value": self.value_deserialized(),
+            "key": {
+                "deserializer": self.key_deserialization.name,
+                "content": self.key_deserialized(),
+            },
+            "value": {
+                "deserializer": self.value_deserialization.name,
+                "content": self.value_deserialized(),
+            },
         }
 
     def key_deserialized(self) -> Any:

--- a/kaskade/themes.py
+++ b/kaskade/themes.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import ClassVar
 
 from rich.theme import Theme as RichTheme
+from textual import events, on
 from textual.app import App, SystemCommand
 from textual.binding import Binding, BindingType
 from textual.screen import Screen
@@ -107,6 +108,29 @@ class KaskadeApp(App, inherit_bindings=False):
         """Open a contextual help window above the current screen."""
         context, bindings = contextual_help(self.screen)
         self.push_screen(HelpScreen(context, bindings))
+
+    @on(events.DeliveryComplete)
+    def on_record_delivery_complete(self, event: events.DeliveryComplete) -> None:
+        """Notify the user after a record export is delivered."""
+        if event.name != "record":
+            return
+        if event.path is None:
+            self.notify("Saved record", title="Record Export")
+        else:
+            self.notify(
+                f"Saved record to [$text-success]{str(event.path)!r}",
+                title="Record Export",
+            )
+
+    @on(events.DeliveryFailed)
+    def on_record_delivery_failed(self, event: events.DeliveryFailed) -> None:
+        """Notify the user when a record export cannot be delivered."""
+        if event.name == "record":
+            self.notify(
+                "Failed to save record",
+                title="Record Export",
+                severity="error",
+            )
 
     def get_system_commands(self, screen: Screen) -> Iterable[SystemCommand]:
         """Add active Kaskade bindings to Textual's command palette."""

--- a/tests/tests_consumer.py
+++ b/tests/tests_consumer.py
@@ -1,0 +1,227 @@
+import json
+import unittest
+from datetime import datetime, timezone
+from io import StringIO
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from textual import events
+
+from kaskade.consumer import (
+    KaskadeConsumer,
+    ListRecords,
+    TopicScreen,
+    deliver_record,
+    record_filename,
+    record_json,
+)
+from kaskade.deserializers import Deserialization, StringDeserializer
+from kaskade.models import Header, Record
+from kaskade.themes import KaskadeApp
+
+
+def exported_record() -> Record:
+    value_deserializer = MagicMock()
+    value_deserializer.deserialize.return_value = {
+        "status": "paid",
+        "customer": "Zoë",
+        "binary": b"\xff",
+    }
+    string_deserializer = StringDeserializer()
+    return Record(
+        topic="orders",
+        partition=2,
+        offset=42,
+        date="2026-08-28 14:12:05.120",
+        headers=[
+            Header("source", b"storefront", string_deserializer),
+            Header("source", b"mobile", string_deserializer),
+        ],
+        key=b"order-1048",
+        value=b"payload",
+        key_deserialization=Deserialization.STRING,
+        value_deserialization=Deserialization.JSON,
+        key_deserializer=string_deserializer,
+        value_deserializer=value_deserializer,
+    )
+
+
+class TestRecordExport(unittest.TestCase):
+    def test_record_dict_contains_complete_nested_export_contract(self) -> None:
+        record = exported_record()
+
+        self.assertEqual(
+            {
+                "topic": "orders",
+                "partition": 2,
+                "offset": 42,
+                "date": "2026-08-28 14:12:05.120",
+                "headers": [("source", "storefront"), ("source", "mobile")],
+                "key": {"deserializer": "STRING", "content": "order-1048"},
+                "value": {
+                    "deserializer": "JSON",
+                    "content": {
+                        "status": "paid",
+                        "customer": "Zoë",
+                        "binary": b"\xff",
+                    },
+                },
+            },
+            record.dict(),
+        )
+
+    def test_record_json_is_readable_utf8_and_stringifies_unsupported_values(self) -> None:
+        exported = record_json(exported_record())
+
+        self.assertTrue(exported.endswith("\n"))
+        self.assertIn("Zoë", exported)
+        self.assertEqual(
+            "b'\\xff'",
+            json.loads(exported)["value"]["content"]["binary"],
+        )
+
+    def test_record_dict_preserves_empty_headers_and_null_content(self) -> None:
+        data = Record(
+            topic="empty",
+            partition=0,
+            offset=0,
+            key_deserialization=Deserialization.STRING,
+            value_deserialization=Deserialization.JSON,
+        ).dict()
+
+        self.assertEqual([], data["headers"])
+        self.assertIsNone(data["key"]["content"])
+        self.assertIsNone(data["value"]["content"])
+
+    def test_record_filename_contains_identity_and_sanitized_export_time(self) -> None:
+        record = Record(topic="orders.v1:archive", partition=2, offset=42)
+
+        filename = record_filename(
+            record,
+            datetime(2026, 8, 28, 14, 20, 10, 930643, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(
+            "kaskade-record-orders_v1_archive-2-42_2026-08-28T14_20_10_930643.json",
+            filename,
+        )
+
+    def test_delivery_uses_screenshot_destination_and_json_metadata(self) -> None:
+        application = MagicMock()
+
+        deliver_record(application, exported_record())
+
+        application.deliver_text.assert_called_once()
+        content = application.deliver_text.call_args.args[0]
+        options = application.deliver_text.call_args.kwargs
+        self.assertIsInstance(content, StringIO)
+        self.assertEqual("orders", json.loads(content.getvalue())["topic"])
+        self.assertNotIn("save_directory", options)
+        self.assertEqual("utf-8", options["encoding"])
+        self.assertEqual("application/json", options["mime_type"])
+        self.assertEqual("record", options["name"])
+
+    def test_successful_delivery_notifies_with_the_saved_path(self) -> None:
+        application = KaskadeApp()
+        application.notify = MagicMock()
+        export_path = Path("/downloads/record.json")
+
+        application.on_record_delivery_complete(
+            events.DeliveryComplete("delivery-key", export_path, "record")
+        )
+
+        application.notify.assert_called_once_with(
+            f"Saved record to [$text-success]{str(export_path)!r}",
+            title="Record Export",
+        )
+
+    def test_browser_delivery_notifies_without_a_path(self) -> None:
+        application = KaskadeApp()
+        application.notify = MagicMock()
+
+        application.on_record_delivery_complete(
+            events.DeliveryComplete("delivery-key", name="record")
+        )
+
+        application.notify.assert_called_once_with("Saved record", title="Record Export")
+
+    def test_failed_delivery_notifies_as_an_error(self) -> None:
+        application = KaskadeApp()
+        application.notify = MagicMock()
+
+        application.on_record_delivery_failed(
+            events.DeliveryFailed("delivery-key", OSError("disk full"), "record")
+        )
+
+        application.notify.assert_called_once_with(
+            "Failed to save record",
+            title="Record Export",
+            severity="error",
+        )
+
+
+class TestRecordExportActions(unittest.IsolatedAsyncioTestCase):
+    @patch("kaskade.consumer.ConsumerService")
+    async def test_ctrl_e_exports_from_table_and_record_details(
+        self, consumer_service: MagicMock
+    ) -> None:
+        record = exported_record()
+        consumer_service.return_value.consume = AsyncMock(return_value=[record])
+        app = KaskadeConsumer(
+            "orders",
+            {},
+            {},
+            {},
+            {},
+            Deserialization.STRING,
+            Deserialization.JSON,
+        )
+        app.deliver_text = MagicMock(return_value="delivery-key")
+
+        async with app.run_test() as pilot:
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            records = app.query_one(ListRecords)
+
+            self.assertIs(record, records.current_record)
+            self.assertTrue(records.check_action("export_record", ()))
+            command_titles = {command.title for command in app.get_system_commands(app.screen)}
+            self.assertIn("Export Record", command_titles)
+
+            await pilot.press("ctrl+e")
+            app.deliver_text.assert_called_once()
+
+            await pilot.press("enter")
+            await pilot.pause()
+            self.assertIsInstance(app.screen, TopicScreen)
+            await pilot.press("ctrl+e")
+            self.assertEqual(2, app.deliver_text.call_count)
+
+    @patch("kaskade.consumer.ConsumerService")
+    async def test_table_export_is_disabled_without_a_record(
+        self, consumer_service: MagicMock
+    ) -> None:
+        consumer_service.return_value.consume = AsyncMock(return_value=[])
+        app = KaskadeConsumer(
+            "orders",
+            {},
+            {},
+            {},
+            {},
+            Deserialization.STRING,
+            Deserialization.JSON,
+        )
+        app.deliver_text = MagicMock()
+
+        async with app.run_test() as pilot:
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            records = app.query_one(ListRecords)
+
+            self.assertFalse(records.check_action("export_record", ()))
+            await pilot.press("ctrl+e")
+            app.deliver_text.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests_themes.py
+++ b/tests/tests_themes.py
@@ -36,7 +36,7 @@ from kaskade.consumer import (
 )
 from kaskade.deserializers import Deserialization
 from kaskade.help import KASKADE_ISSUES_URL, KASKADE_URL, HelpableModalScreen, HelpScreen
-from kaskade.models import Topic
+from kaskade.models import Record, Topic
 from kaskade.themes import (
     DEFAULT_THEME,
     EVA01_THEME,
@@ -131,7 +131,7 @@ class TestThemes(unittest.TestCase):
             CreateTopicScreen: ["Create Topic", "Back", "Help"],
             FilterRecordScreen: ["Apply Filters", "Back", "Help"],
             ChunkSizeScreen: ["Select", "Back", "Help"],
-            TopicScreen: ["Back", "Help"],
+            TopicScreen: ["Export Record", "Back", "Help"],
             HelpScreen: ["Back"],
         }
 
@@ -518,7 +518,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
 
             async with app.run_test() as pilot:
                 records_table = app.query_one("#records-table", DataTable)
-                app.push_screen(TopicScreen("orders", 0, 1, {"value": "record"}))
+                app.push_screen(TopicScreen(Record(topic="orders", partition=0, offset=1)))
                 await pilot.pause()
 
                 details = app.screen.query_one(".record-details", ScrollableContainer)


### PR DESCRIPTION
## Summary

Export selected consumed records from the table or Record Details with Ctrl+E. Deliver readable JSON to the same destination as screenshots, preserve record metadata and nested key/value deserializer information, and notify users when delivery succeeds or fails.

Closes #74

## Verification

- [x] uv run --locked python -m scripts.analyze
- [x] uv run --locked python -m scripts.tests
- [x] Relevant end-to-end checks passed through the commit hooks

## User-facing changes

- Add Ctrl+E Export Record to consumer records and Record Details.
- Add JSON delivery success and failure notifications.
- Document record exports and label the Admin and Consumer README screenshots.

## Checklist

- [x] Tests cover the changed behavior.
- [x] Documentation and examples reflect the change.
- [x] No secrets or private infrastructure details are included.
- [x] The title follows Conventional Commits and is suitable for release notes.

Assisted-by: Codex GPT-5