### PR TITLE
fix(consumer): improve record json modal

### DIFF
--- a/kaskade/consumer.py
+++ b/kaskade/consumer.py
@@ -4,11 +4,12 @@ from io import StringIO
 from typing import ClassVar
 
 from confluent_kafka import KafkaException
+from rich.json import JSON
 from textual import work
 from textual.app import App, ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Container
-from textual.widgets import DataTable, Footer, Input, OptionList, Pretty
+from textual.widgets import DataTable, Footer, Input, OptionList, Static
 from textual.widgets.option_list import Option
 
 from kaskade.colors import PRIMARY
@@ -45,6 +46,14 @@ CONSUMER_EXCEPTIONS: tuple[type[Exception], ...] = (
 def record_json(record: Record) -> str:
     """Return a readable JSON representation of a consumed record."""
     return json.dumps(record.dict(), indent=2, ensure_ascii=False, default=str) + "\n"
+
+
+def record_json_renderable(data: object) -> JSON:
+    """Return syntax-highlighted, indented JSON that wraps long values."""
+    renderable = JSON.from_data(data, indent=2, ensure_ascii=False, default=str)
+    renderable.text.no_wrap = False
+    renderable.text.overflow = "fold"
+    return renderable
 
 
 def record_filename(record: Record, exported_at: datetime | None = None) -> str:
@@ -242,7 +251,7 @@ class TopicScreen(HelpableModalScreen):
         container = KaskadeScrollableContainer(classes="record-details")
         container.border_title = rf"[{PRIMARY}]Record[/] \[[{PRIMARY}]{self.record.topic}[/]]\[[{PRIMARY}]{self.record.partition}[/]]\[[{PRIMARY}]{self.record.offset}[/]]"
         with container:
-            yield Pretty(self.data)
+            yield Static(record_json_renderable(self.data), classes="record-json")
         yield Footer(compact=True)
 
     def action_close(self) -> None:

--- a/kaskade/styles.css
+++ b/kaskade/styles.css
@@ -153,10 +153,16 @@ ChunkSizeScreen > OptionList {
 
 TopicScreen > .record-details {
     border: $secondary;
-    width: 90;
+    width: 100;
     max-width: 95%;
     height: 80%;
     background: $surface;
+}
+
+TopicScreen .record-json {
+    width: 100%;
+    height: auto;
+    text-wrap: wrap;
 }
 
 DescribeTopicScreen > TabbedContent {

--- a/kaskade/themes.py
+++ b/kaskade/themes.py
@@ -211,6 +211,12 @@ class KaskadeApp(App, inherit_bindings=False):
             "success": _rich_color(theme.success or theme.primary),
             "accent": _rich_color(theme.accent or theme.primary),
             "repr.str": _rich_color(theme.primary),
+            "json.key": f"bold {_rich_color(theme.primary)}",
+            "json.str": _rich_color(theme.primary),
+            "json.number": _rich_color(theme.secondary or theme.primary),
+            "json.bool_true": _rich_color(theme.success or theme.primary),
+            "json.bool_false": _rich_color(theme.error or theme.primary),
+            "json.null": _rich_color(theme.warning or theme.primary),
         }
         self.console.push_theme(RichTheme(styles))
         self._rich_theme_pushed = True

--- a/tests/tests_consumer.py
+++ b/tests/tests_consumer.py
@@ -14,6 +14,7 @@ from kaskade.consumer import (
     deliver_record,
     record_filename,
     record_json,
+    record_json_renderable,
 )
 from kaskade.deserializers import Deserialization, StringDeserializer
 from kaskade.help import HelpScreen
@@ -80,6 +81,17 @@ class TestRecordExport(unittest.TestCase):
             "b'\\xff'",
             json.loads(exported)["value"]["content"]["binary"],
         )
+
+    def test_record_json_renderable_expands_nested_objects_and_wraps_long_values(self) -> None:
+        renderable = record_json_renderable(exported_record().dict())
+
+        self.assertEqual(record_json(exported_record()).rstrip("\n"), renderable.text.plain)
+        self.assertIn(
+            '  "key": {\n    "deserializer": "STRING",\n    "content": "order-1048"\n  }',
+            renderable.text.plain,
+        )
+        self.assertFalse(renderable.text.no_wrap)
+        self.assertEqual("fold", renderable.text.overflow)
 
     def test_record_dict_preserves_empty_headers_and_null_content(self) -> None:
         data = Record(

--- a/tests/tests_themes.py
+++ b/tests/tests_themes.py
@@ -75,6 +75,8 @@ class TestThemes(unittest.TestCase):
 
         self.assertEqual("#bd93f9", app.console.get_style("primary").color.get_truecolor().hex)
         self.assertEqual("#6272a4", app.console.get_style("secondary").color.get_truecolor().hex)
+        self.assertEqual("#bd93f9", app.console.get_style("json.str").color.get_truecolor().hex)
+        self.assertEqual("#6272a4", app.console.get_style("json.number").color.get_truecolor().hex)
 
     def test_updates_rich_semantic_styles_for_ansi_themes(self):
         app = KaskadeApp()
@@ -629,6 +631,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
 
                 details = app.screen.query_one(".record-details", ScrollableContainer)
                 self.assertIs(details, app.screen.focused)
+                self.assertEqual(100, details.styles.width.value)
 
                 await pilot.press("escape")
                 self.assertIs(records_table, app.screen.focused)


### PR DESCRIPTION
Render record details as fully indented, syntax-highlighted JSON while preserving overflow wrapping and making the responsive modal wider.

Validation:
- code analysis
- unit tests
- screenshot generation
- end-to-end tests

Assisted-by: Codex GPT-5