### PR TITLE
fix(ci): check out tag before GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Download release bundle
         uses: actions/download-artifact@v8.0.1
         with:


### PR DESCRIPTION
Summary:
- check out the pushed release tag before invoking gh release create
- fetch full history without persisting checkout credentials

Validation:
- actionlint
- project analysis
- unit tests
- end-to-end tests