### PR TITLE
docs(readme): reorganize feature overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,4 +127,5 @@ reviewed and tested by the maintainer before they are included.
 
 <p>
 <a href="https://github.com/littlehorse-enterprises/littlehorse"><img alt="Sponsored by LittleHorse" src="https://raw.githubusercontent.com/sauljabin/kaskade/main/images/littlehorse-badge.svg"></a>
+<a href="https://textual.textualize.io/"><img alt="Built with Textual" src="https://raw.githubusercontent.com/sauljabin/kaskade/main/images/textual-badge.svg"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -22,24 +22,6 @@
 
 Bring Kafka along for the terminal ride. Kaskade gives you a stylish, keyboard-friendly way to explore clusters, manage topics, and consume records.
 
-## Features
-
-| Area | Capability | Availability |
-| --- | --- | --- |
-| General | Customize themes and keybindings | Supported |
-| Admin | Browse topics, partitions, groups, and group members | Supported |
-| Admin | View topic lag, replicas, and record counts | Supported |
-| Admin | Create, edit, and delete topics | Supported, except changing the replication factor |
-| Admin | Filter topics by name | Supported |
-| Admin | Copy topic names to the clipboard | Supported in [OSC 52-compatible terminals](https://github.com/sauljabin/kaskade/blob/main/USAGE.md#osc-52-compatibility) |
-| Admin | Refresh topic metadata and metrics | Automatic every 30 seconds, configurable, or manual |
-| Consumer | Deserialize keys and values as bytes, JSON, string, integer, long, float, boolean, or double | Supported |
-| Consumer | Filter records by key, value, header, and/or partition | Supported |
-| Consumer | Copy individual records as JSON | Supported in [OSC 52-compatible terminals](https://github.com/sauljabin/kaskade/blob/main/USAGE.md#osc-52-compatibility) |
-| Consumer | Export individual records as JSON | Supported |
-| Consumer | Deserialize with Schema Registry | Avro and JSON are supported; Protobuf is not supported |
-| Consumer | Deserialize without Schema Registry | Avro and Protobuf are supported |
-
 ## Screenshots
 
 <table width="100%">
@@ -56,6 +38,36 @@ Bring Kafka along for the terminal ride. Kaskade gives you a stylish, keyboard-f
     </td>
   </tr>
 </table>
+
+## Features
+
+### Kafka administration
+
+- Browse topics, partitions, consumer groups, and group members
+- Inspect topic lag, replicas, and record counts
+- Create, edit, delete, and filter topics
+- Refresh topic metadata and metrics automatically or manually
+- Copy topic names to the clipboard
+
+### Record consumption
+
+- Deserialize keys and values as bytes, JSON, string, integer, long, float,
+  boolean, or double
+- Filter records by key, value, header, or partition
+- Copy or export individual records as JSON
+- Deserialize Avro and JSON data with Schema Registry
+- Deserialize Avro and Protobuf data without Schema Registry
+
+### Terminal experience
+
+- Customize themes and keybindings
+- Copy data through an [OSC 52-compatible terminal](https://github.com/sauljabin/kaskade/blob/main/USAGE.md#osc-52-compatibility)
+
+## Current limitations
+
+- Topic replication factors cannot be changed
+- Schema Registry does not support Protobuf
+- Clipboard integration requires an OSC 52-compatible terminal
 
 ## Quick start
 

--- a/images/textual-badge.svg
+++ b/images/textual-badge.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="133" height="20" role="img" aria-labelledby="title desc">
+  <title id="title">Built with Textual</title>
+  <desc id="desc">A badge with the Textual logo and the text Built with Textual.</desc>
+  <rect width="82" height="20" fill="#555555"/>
+  <rect x="82" width="51" height="20" fill="#5C2D80"/>
+  <path fill="#FFFFFF" fill-rule="evenodd" clip-rule="evenodd" d="M618 0h461l-77.4 174.1-141.3 79.5h-96L531.3 728 390.7 833.4H237.5l33.6-504.2H75.1L0 160.3l112.9-84.7h370.7L618 0zM470.3 102.3l-11.2 48.9H56.6l65.2-48.9h348.5zM37.1 178h415.8L308.4 806.7h-42.3l33.6-504.2H92.4L37.1 178zm298.7 628.7 161.9-704.3h405.7l-55.3 124.5H612.5L377.3 806.7h-41.5zM920.5 75.6H538.1l87-48.9h382.5l-87.1 48.9z" transform="translate(4 3) scale(.0168)"/>
+  <text x="54" y="14" fill="#FFFFFF" font-family="Verdana, Geneva, DejaVu Sans, sans-serif" font-size="11" text-anchor="middle">built with</text>
+  <text x="107.5" y="14" fill="#FFFFFF" font-family="Verdana, Geneva, DejaVu Sans, sans-serif" font-size="11" text-anchor="middle">Textual</text>
+</svg>


### PR DESCRIPTION
## Summary

- move screenshots ahead of the feature overview
- group shipped capabilities into administration, consumption, and terminal experience
- separate current limitations from available features

## Pipeline verification

- `uv lock --check`
- `uv run --locked python -m scripts.analyze`
- `uv run --locked python -m scripts.tests`
- `uv run --locked python -m scripts.tests --e2e`
- `uv build --clear`
- pre-commit hooks