### PR TITLE
fix(admin): avoid refresh updates after shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ See [GitHub Releases](https://github.com/sauljabin/kaskade/releases) for release
 
 For Q&A go to [GitHub Discussions](https://github.com/sauljabin/kaskade/discussions/categories/q-a).
 
+## Security
+
+Report suspected vulnerabilities privately by following the [Kaskade security policy](https://github.com/sauljabin/kaskade/blob/main/SECURITY.md).
+
 ## Donations
 
 If Kaskade is useful to you, consider [supporting its development on GitHub Sponsors](https://github.com/sponsors/sauljabin).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are provided for the latest stable Kaskade release. Users should
+upgrade to the newest release before reporting an issue that may already be
+fixed.
+
+| Version | Supported |
+| --- | --- |
+| Latest stable release | Yes |
+| Older releases | No |
+| `main` development branch | Best effort; not a supported release |
+
+## Reporting a vulnerability
+
+Do not report suspected vulnerabilities in a public issue, discussion, pull
+request, log, or screenshot.
+
+Use [GitHub private vulnerability reporting](https://github.com/sauljabin/kaskade/security/advisories/new)
+whenever possible. If that form is unavailable, email
+`sauljabin@gmail.com` with the subject `[Kaskade security]` and include only the
+minimum sensitive detail needed to establish contact.
+
+Include the following when it is safe to do so:
+
+- The affected Kaskade version or commit.
+- Operating system, Python version, installation method, and Kafka distribution.
+- A concise description of the vulnerability and its likely impact.
+- Reproduction steps or a minimal proof of concept using test data.
+- Whether credentials, private broker details, or production data may have been
+  exposed.
+- Any known mitigations and your preferred name for advisory credit.
+
+Never send real passwords, tokens, private keys, certificates, production
+records, or private infrastructure details. Replace them with synthetic values.
+
+Security-sensitive examples include credential or configuration disclosure,
+unsafe file handling, command execution, authorization-boundary mistakes, and
+dependency vulnerabilities with a demonstrated impact on Kaskade.
+
+## Handling and disclosure
+
+The maintainer will assess the report, request missing information when needed,
+and keep confirmed vulnerabilities private while a fix is prepared. Resolution
+time depends on severity, complexity, and maintainer availability; reporters
+will receive material status updates through the private report.
+
+Please allow time for investigation and remediation before publishing details.
+The maintainer and reporter should coordinate disclosure, release, advisory,
+and credit timing. Confirmed vulnerabilities may be published as GitHub
+repository security advisories after a fixed release is available.
+
+Questions, troubleshooting, hardening suggestions without a concrete security
+impact, and ordinary bugs belong in GitHub Discussions or the public issue
+tracker after all sensitive information has been removed.

--- a/kaskade/admin.py
+++ b/kaskade/admin.py
@@ -766,6 +766,8 @@ class ListTopics(Container):
     def _complete_refresh(self, generation: int, table: DataTable[Any]) -> None:
         if not self.refresh_coordinator.complete(generation):
             return
+        if not self.is_attached:
+            return
         table.loading = False
         self._update_status(refreshing=False)
         refresh_completed = getattr(self.app, "admin_refresh_completed", None)

--- a/tests/unit/tests_admin.py
+++ b/tests/unit/tests_admin.py
@@ -237,6 +237,25 @@ class TestAdminRefresh(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(all(task.done() and task.cancelled() for task in tasks))
 
+    async def test_shutdown_cancels_active_refresh_without_updating_detached_widgets(self) -> None:
+        enrichment_gate = asyncio.Event()
+        topic = Topic(name="orders", partitions=[Partition(id=0)])
+        service = MagicMock()
+        service.metadata = AsyncMock(return_value={"orders": topic})
+
+        async def wait_for_enrichment() -> EnrichmentResult:
+            await enrichment_gate.wait()
+            return EnrichmentResult()
+
+        service.enrich_offsets.side_effect = lambda topics: wait_for_enrichment()
+        service.load_groups.side_effect = wait_for_enrichment
+
+        with patch("kaskade.admin.TopicService", return_value=service):
+            app = KaskadeAdmin({})
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                self.assertEqual(1, len(app.query_one(DataTable).rows))
+
     async def test_command_line_interval_overrides_config(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             config_path = Path(temporary_directory) / "config.yaml"


### PR DESCRIPTION
## Summary

- skip refresh UI and callback work after the admin topic list detaches
- cover shutdown while metric enrichment is still active
- add the project security policy and link it from the README

## Testing

- code analysis
- unit tests
- Docker-backed e2e tests
- pre-commit hooks, including generated asset checks