### PR TITLE
docs: remove hard-coded release versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Kaskade version
       description: Run `kaskade --version` to obtain the installed version.
-      placeholder: "4.1.0"
+      placeholder: "Paste the command output"
     validations:
       required: true
   - type: dropdown

--- a/AGENT.md
+++ b/AGENT.md
@@ -231,6 +231,10 @@ individual script modules focused on executable workflows.
   static package version.
 - GitHub Releases are the canonical changelog. Do not add a maintained changelog
   file or a version-bump commit.
+- Never hard-code Kaskade's current release version in documentation, issue
+  templates, examples, or release commands. Refer to `kaskade --version`, use a
+  `MAJOR.MINOR.PATCH` placeholder, or derive the version from Git metadata so a
+  release does not require follow-up file edits.
 - Release tags must point to commits on `main`. The protected release workflow
   builds once, verifies the tag against the artifacts, and publishes those same
   artifacts to PyPI and GitHub after approval.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -143,8 +143,9 @@ Choose the next version according to [Semantic Versioning](https://semver.org/),
 then create and push an annotated tag:
 
 ```bash
-git tag -a v4.1.0 -m "Release v4.1.0"
-git push origin v4.1.0
+release_version="MAJOR.MINOR.PATCH"
+git tag -a "v${release_version}" -m "Release v${release_version}"
+git push origin "v${release_version}"
 ```
 
 The release workflow validates that the tag is exactly `vMAJOR.MINOR.PATCH` and


### PR DESCRIPTION
## Summary

- Replace the concrete Kaskade version in the bug-report form with a command-output prompt.
- Make release tagging instructions use a `MAJOR.MINOR.PATCH` variable.
- Record the version-neutral documentation convention in `AGENT.md`.

## Verification

- [x] `uv run --locked python -m scripts.analyze`
- [x] `uv run --locked python -m scripts.tests`
- [x] Pre-commit E2E test suite

## User-facing changes

Bug reports and release instructions no longer embed a Kaskade release number that must be updated later.

## Checklist

- [x] Tests cover the changed behavior.
- [x] Documentation and examples reflect the change.
- [x] No secrets or private infrastructure details are included.
- [x] The title follows Conventional Commits and is suitable for release notes.

Assisted-by: Codex GPT-5