### PR TITLE
feat(auth): add aws msk iam authentication

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -48,6 +48,12 @@ Missing, empty, malformed, or partially invalid Kaskade configuration must not
 make startup fragile. Ignore invalid entries, retain valid entries, and surface
 warnings in the application.
 
+Amazon MSK IAM authentication is enabled with `--aws region=<region>` in both
+admin and consumer modes. Keep AWS-specific CLI settings in the repeatable
+`--aws property=value` form and validate them before constructing Kafka clients.
+The signer dependency baseline is `aws-msk-iam-sasl-signer-python>=1.0`; do not
+raise its minimum version without requiring newer functionality.
+
 ## Runtime Initialization
 
 - Importing `kaskade` must not create directories, open files, or modify the root

--- a/AGENT.md
+++ b/AGENT.md
@@ -55,6 +55,10 @@ Kafka clients. The signer dependency baseline is
 `aws-msk-iam-sasl-signer-python>=1.0`; do not raise its minimum version without
 requiring newer functionality.
 
+Keep Amazon MSK authorization documentation split by authentication mechanism:
+IAM-authenticated clients use `kafka-cluster` IAM policies, while SASL/SCRAM and
+mTLS principals use Apache Kafka ACLs. Kafka ACLs do not authorize IAM identities.
+
 ## Runtime Initialization
 
 - Importing `kaskade` must not create directories, open files, or modify the root

--- a/AGENT.md
+++ b/AGENT.md
@@ -48,11 +48,12 @@ Missing, empty, malformed, or partially invalid Kaskade configuration must not
 make startup fragile. Ignore invalid entries, retain valid entries, and surface
 warnings in the application.
 
-Amazon MSK IAM authentication is enabled with `--aws region=<region>` in both
-admin and consumer modes. Keep AWS-specific CLI settings in the repeatable
-`--aws property=value` form and validate them before constructing Kafka clients.
-The signer dependency baseline is `aws-msk-iam-sasl-signer-python>=1.0`; do not
-raise its minimum version without requiring newer functionality.
+Amazon MSK IAM authentication is enabled with `--aws region=<region>` in admin,
+consumer, and the sandbox population tool. Keep AWS-specific CLI settings in
+the repeatable `--aws property=value` form and validate them before constructing
+Kafka clients. The signer dependency baseline is
+`aws-msk-iam-sasl-signer-python>=1.0`; do not raise its minimum version without
+requiring newer functionality.
 
 ## Runtime Initialization
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -55,10 +55,6 @@ Kafka clients. The signer dependency baseline is
 `aws-msk-iam-sasl-signer-python>=1.0`; do not raise its minimum version without
 requiring newer functionality.
 
-Keep Amazon MSK authorization documentation split by authentication mechanism:
-IAM-authenticated clients use `kafka-cluster` IAM policies, while SASL/SCRAM and
-mTLS principals use Apache Kafka ACLs. Kafka ACLs do not authorize IAM identities.
-
 ## Runtime Initialization
 
 - Importing `kaskade` must not create directories, open files, or modify the root

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -202,6 +202,18 @@ To use Apicurio instead, populate a fresh sandbox with its compatibility API:
 uv run python -m sandbox --registry http://localhost:18082/apis/ccompat/v7
 ```
 
+To populate an Amazon MSK cluster that uses IAM authentication, run the tool from
+a network with access to the brokers and pass the IAM bootstrap servers and AWS
+region. AWS credentials use the standard provider chain:
+
+```bash
+uv run python -m sandbox \
+    --bootstrap-servers "${AWS_MSK_BOOTSTRAP_SERVERS}" \
+    --aws region=us-east-1
+```
+
+The Schema Registry URL remains independently configurable with `--registry`.
+
 Read help messages:
 
 ```bash

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -213,6 +213,9 @@ uv run python -m sandbox \
 ```
 
 The Schema Registry URL remains independently configurable with `--registry`.
+Use the sandbox population policy in the
+[Amazon MSK IAM authorization documentation](USAGE.md#required-iam-authorization-policy)
+for the required cluster and topic permissions.
 
 Read help messages:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -202,6 +202,40 @@ To use Apicurio instead, populate a fresh sandbox with its compatibility API:
 uv run python -m sandbox --registry http://localhost:18082/apis/ccompat/v7
 ```
 
+#### Query registry APIs with HTTPie
+
+After populating the sandbox, use [HTTPie](https://httpie.io/) to inspect the
+registered subjects and schemas. Query Confluent Schema Registry at port
+`18081`:
+
+```bash
+http GET http://localhost:18081/subjects
+http GET http://localhost:18081/subjects/avro-schema-value/versions
+http GET http://localhost:18081/subjects/avro-schema-value/versions/latest
+http GET http://localhost:18081/config
+```
+
+Apicurio exposes the same subject operations through its Confluent-compatible
+API:
+
+```bash
+http GET http://localhost:18082/apis/ccompat/v7/subjects
+http GET http://localhost:18082/apis/ccompat/v7/subjects/avro-schema-value/versions
+http GET http://localhost:18082/apis/ccompat/v7/subjects/avro-schema-value/versions/latest
+http GET http://localhost:18082/apis/ccompat/v7/config
+```
+
+Use Apicurio's native Core Registry API v3 to search its artifacts and versions:
+
+```bash
+http GET http://localhost:18082/apis/registry/v3/search/artifacts
+http GET http://localhost:18082/apis/registry/v3/search/versions
+```
+
+The `avro-schema-value` subject exists after populating the `avro-schema` topic.
+Substitute another name returned by the `/subjects` request when testing a
+different schema-backed topic.
+
 To populate an Amazon MSK cluster that uses IAM authentication, run the tool from
 a network with access to the brokers and pass the IAM bootstrap servers and AWS
 region. AWS credentials use the standard provider chain:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -171,42 +171,74 @@ The standalone `sandbox` package owns its Compose environment, population tools,
 and Avro, JSON Schema, and Protobuf models. These models are intentionally
 separate from the fixtures under `tests/unit`.
 
-Start the sandbox's three-node Confluent Kafka cluster, Apicurio Registry, and
-Confluent Schema Registry:
+Use this sequence for a complete manual test:
+
+1. Start the local services.
+2. Populate all topics or a selected subset.
+3. Inspect registry data when testing schema-backed topics.
+4. Run the Admin and Consumer smoke tests.
+5. Stop the services and remove their volumes.
+
+#### Start the local sandbox
+
+Start the three-node Confluent Kafka cluster, Confluent Schema Registry, and
+Apicurio Registry:
 
 ```bash
 docker compose --project-directory sandbox up -d
 ```
 
-Stop sandbox:
+The sandbox exposes:
 
-```bash
-docker compose --project-directory sandbox down -v
-```
+| Service | Address |
+| --- | --- |
+| Kafka brokers | `localhost:19092`, `localhost:29092`, `localhost:39092` |
+| Confluent Schema Registry | `http://localhost:18081` |
+| Apicurio Confluent-compatible API | `http://localhost:18082/apis/ccompat/v7` |
+| Apicurio Core Registry API | `http://localhost:18082/apis/registry/v3` |
 
-Kafka is available at `localhost:19092`, `localhost:29092`, and
-`localhost:39092`. Confluent Schema Registry is available at
-`http://localhost:18081`; Apicurio's compatibility API is available at
-`http://localhost:18082/apis/ccompat/v7`. Image versions and the Kafka cluster
-ID are defined in `sandbox/.env`.
+Image versions and the Kafka cluster ID are defined in `sandbox/.env`.
 
-Populate Kafka using Confluent Schema Registry:
+#### Populate test topics
+
+The default command creates and populates every available sandbox topic using
+Confluent Schema Registry:
 
 ```bash
 uv run python -m sandbox
 ```
 
-To use Apicurio instead, populate a fresh sandbox with its compatibility API:
+Repeat `--topic` to populate only a subset. The accepted topic names are listed
+by `uv run python -m sandbox --help`:
+
+```bash
+uv run python -m sandbox --topic string --topic errors
+```
+
+Topic creation uses 10 partitions and the broker defaults for replication
+factor and minimum in-sync replicas. Override them when testing a specific
+topology:
+
+```bash
+uv run python -m sandbox \
+    --partitions 6 \
+    --replication-factor 3 \
+    --min-insync-replicas 2
+```
+
+To test Apicurio, start from an empty sandbox and populate it through the
+Confluent-compatible API:
 
 ```bash
 uv run python -m sandbox --registry http://localhost:18082/apis/ccompat/v7
 ```
 
-#### Query registry APIs with HTTPie
+#### Inspect registry APIs with HTTPie
 
 After populating the sandbox, use [HTTPie](https://httpie.io/) to inspect the
-registered subjects and schemas. Query Confluent Schema Registry at port
-`18081`:
+registered subjects and schemas.
+
+Query Confluent Schema Registry:
 
 ```bash
 http GET http://localhost:18081/subjects
@@ -215,8 +247,7 @@ http GET http://localhost:18081/subjects/avro-schema-value/versions/latest
 http GET http://localhost:18081/config
 ```
 
-Apicurio exposes the same subject operations through its Confluent-compatible
-API:
+Query Apicurio's Confluent-compatible API:
 
 ```bash
 http GET http://localhost:18082/apis/ccompat/v7/subjects
@@ -225,7 +256,7 @@ http GET http://localhost:18082/apis/ccompat/v7/subjects/avro-schema-value/versi
 http GET http://localhost:18082/apis/ccompat/v7/config
 ```
 
-Use Apicurio's native Core Registry API v3 to search its artifacts and versions:
+Query Apicurio's native Core Registry API:
 
 ```bash
 http GET http://localhost:18082/apis/registry/v3/search/artifacts
@@ -235,6 +266,8 @@ http GET http://localhost:18082/apis/registry/v3/search/versions
 The `avro-schema-value` subject exists after populating the `avro-schema` topic.
 Substitute another name returned by the `/subjects` request when testing a
 different schema-backed topic.
+
+#### Populate a remote Amazon MSK cluster
 
 To populate an Amazon MSK cluster that uses IAM authentication, run the tool from
 a network with access to the brokers and pass the IAM bootstrap servers and AWS
@@ -250,58 +283,56 @@ The Schema Registry URL remains independently configurable with `--registry`.
 See the sandbox requirements under [IAM permissions](USAGE.md#iam-permissions)
 or [Kafka ACLs](USAGE.md#kafka-acls).
 
-Read help messages:
+#### Run application smoke tests
+
+Confirm both command interfaces render successfully:
 
 ```bash
 uv run kaskade admin --help
 uv run kaskade consumer --help
 ```
 
-Test admin:
+Open the Admin application and verify the populated topics and their metadata:
 
 ```bash
 uv run kaskade admin -b localhost:19092
 ```
 
-Test consumer without deserialization:
+##### Primitive and JSON consumers
+
+Start with raw bytes:
 
 ```bash
 uv run kaskade consumer -b localhost:19092 --earliest -t string
 ```
 
-Test consumer with nulls:
+Test null keys and values:
 
 ```bash
 uv run kaskade consumer -b localhost:19092 --earliest -k string -v string -t null
 ```
 
-Test consumer with deserializers:
+Test every primitive deserializer:
 
 ```bash
 uv run kaskade consumer -b localhost:19092 --earliest -k string -v string -t string
-```
-
-```bash
 uv run kaskade consumer -b localhost:19092 --earliest -k string -v integer -t integer
-```
-
-```bash
 uv run kaskade consumer -b localhost:19092 --earliest -k string -v long -t long
-```
-
-```bash
 uv run kaskade consumer -b localhost:19092 --earliest -k string -v float -t float
-```
-
-```bash
 uv run kaskade consumer -b localhost:19092 --earliest -k string -v double -t double
-```
-
-```bash
 uv run kaskade consumer -b localhost:19092 --earliest -k string -v boolean -t boolean
 ```
 
-Test json consumer with Schema Registry:
+Test JSON payloads without Schema Registry:
+
+```bash
+uv run kaskade consumer -b localhost:19092 --earliest -k string -v json -t json
+uv run kaskade consumer -b localhost:19092 --earliest -k string -v json -t json-schema
+```
+
+##### Schema Registry consumers
+
+Test a JSON Schema payload through Confluent Schema Registry:
 
 ```bash
 uv run kaskade consumer -b localhost:19092 --earliest -t json-schema \
@@ -309,7 +340,7 @@ uv run kaskade consumer -b localhost:19092 --earliest -t json-schema \
         --registry url=http://localhost:18081
 ```
 
-Test per-field Schema Registry deserialization fallbacks:
+Test independent key and value deserialization fallbacks:
 
 ```bash
 uv run kaskade consumer -b localhost:19092 --earliest -t errors \
@@ -321,17 +352,7 @@ The `errors` topic cycles through a malformed key, malformed value, both fields
 malformed, and a fully valid record. Malformed fields contain randomized bytes,
 and the `sandbox-error-case` header identifies each case.
 
-Test json consumer without Schema Registry:
-
-```bash
-uv run kaskade consumer -b localhost:19092 --earliest -k string -v json -t json
-```
-
-```bash
-uv run kaskade consumer -b localhost:19092 --earliest -k string -v json -t json-schema
-```
-
-Test avro consumer with Schema Registry:
+Test an Avro payload through Confluent Schema Registry:
 
 ```bash
 uv run kaskade consumer -b localhost:19092 --earliest -t avro-schema \
@@ -339,7 +360,7 @@ uv run kaskade consumer -b localhost:19092 --earliest -t avro-schema \
         --registry url=http://localhost:18081
 ```
 
-Test avro consumer with Apicurio Registry:
+Test the same Avro payload through Apicurio after populating that registry:
 
 ```bash
 uv run kaskade consumer -b localhost:19092 --earliest -t avro-schema \
@@ -347,25 +368,37 @@ uv run kaskade consumer -b localhost:19092 --earliest -t avro-schema \
         --registry url=http://localhost:18082/apis/ccompat/v7
 ```
 
-Test avro consumer without Schema Registry:
+##### Local-schema consumers
+
+Test raw and Confluent-framed Avro payloads with a local schema:
 
 ```bash
 uv run kaskade consumer -b localhost:19092 --earliest -t avro \
         -k string -v avro \
         --avro value=sandbox/avro_model/user.avsc
-```
 
-```bash
 uv run kaskade consumer -b localhost:19092 --earliest -t avro-schema \
         -k string -v avro \
         --avro value=sandbox/avro_model/user.avsc \
         --avro framing=confluent
 ```
 
-Test protobuf consumer:
+Test raw and Confluent-framed Protobuf payloads with the checked-in descriptor:
 
-The checked-in descriptor is generated from `sandbox/protobuf_model/user.proto`.
-After changing the schema, regenerate the sandbox artifacts with `protoc`:
+```bash
+uv run kaskade consumer -b localhost:19092 --earliest -t protobuf \
+        -k string -v protobuf \
+        --protobuf descriptor=sandbox/protobuf_model/user.desc \
+        --protobuf value=User
+
+uv run kaskade consumer -b localhost:19092 --earliest -t protobuf-schema \
+        -k string -v protobuf \
+        --protobuf descriptor=sandbox/protobuf_model/user.desc \
+        --protobuf value=User
+```
+
+The descriptor is generated from `sandbox/protobuf_model/user.proto`. After
+changing the schema, regenerate the sandbox artifacts with `protoc`:
 
 ```bash
 protoc --include_imports \
@@ -376,16 +409,11 @@ protoc --include_imports \
        sandbox/protobuf_model/user.proto
 ```
 
-```bash
-uv run kaskade consumer -b localhost:19092 --earliest -t protobuf \
-        -k string -v protobuf \
-        --protobuf descriptor=sandbox/protobuf_model/user.desc \
-        --protobuf value=User
-```
+#### Stop the local sandbox
+
+Remove the containers, networks, and persisted test data when manual testing is
+complete:
 
 ```bash
-uv run kaskade consumer -b localhost:19092 --earliest -t protobuf-schema \
-        -k string -v protobuf \
-        --protobuf descriptor=sandbox/protobuf_model/user.desc \
-        --protobuf value=User
+docker compose --project-directory sandbox down -v
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -213,11 +213,8 @@ uv run python -m sandbox \
 ```
 
 The Schema Registry URL remains independently configurable with `--registry`.
-Use the sandbox population policy in the
-[Amazon MSK IAM authorization documentation](USAGE.md#required-iam-authorization-policy)
-when connecting with `--aws`. For SASL/SCRAM or mTLS connections, grant the
-sandbox principal the Kafka ACLs in the
-[Apache Kafka ACL documentation](USAGE.md#apache-kafka-acls-for-saslscram-and-mtls).
+See the sandbox requirements under [IAM permissions](USAGE.md#iam-permissions)
+or [Kafka ACLs](USAGE.md#kafka-acls).
 
 Read help messages:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -215,7 +215,9 @@ uv run python -m sandbox \
 The Schema Registry URL remains independently configurable with `--registry`.
 Use the sandbox population policy in the
 [Amazon MSK IAM authorization documentation](USAGE.md#required-iam-authorization-policy)
-for the required cluster and topic permissions.
+when connecting with `--aws`. For SASL/SCRAM or mTLS connections, grant the
+sandbox principal the Kafka ACLs in the
+[Apache Kafka ACL documentation](USAGE.md#apache-kafka-acls-for-saslscram-and-mtls).
 
 Read help messages:
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Bring Kafka along for the terminal ride. Kaskade gives you a stylish, keyboard-f
 - Browse topics, partitions, consumer groups, and group members
 - Inspect topic lag, replicas, and record counts
 - Create, edit, delete, and filter topics
+- Connect to Amazon MSK clusters with AWS IAM authentication
 - Refresh topic metadata and metrics automatically or manually
 - Copy topic names to the clipboard
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -239,7 +239,28 @@ Configuration precedence, from lowest to highest, is:
 1. Properties loaded from `--config-file`.
 2. Repeated `-c/--config property=value` options.
 3. `-b/--bootstrap-servers` for `bootstrap.servers`.
-4. In consumer mode, `--earliest` for `auto.offset.reset=earliest`.
+4. `--aws property=value` for the Amazon MSK IAM authentication properties.
+5. In consumer mode, `--earliest` for `auto.offset.reset=earliest`.
+
+### Amazon MSK with IAM authentication
+
+Pass the AWS region to enable IAM authentication in either mode:
+
+```bash
+kaskade admin -b ${AWS_MSK_BOOTSTRAP_SERVERS} --aws region=us-east-1
+
+kaskade consumer -b ${AWS_MSK_BOOTSTRAP_SERVERS} -t my-topic \
+        --aws region=us-east-1
+```
+
+Kaskade configures `security.protocol=SASL_SSL`, `sasl.mechanism=OAUTHBEARER`,
+and automatic token refresh. Credentials are discovered through the standard AWS
+credential provider chain, so environment variables, shared AWS profiles (including
+`AWS_PROFILE`), and IAM roles attached to AWS workloads are supported without passing
+credentials to Kaskade.
+
+See [Configure clients for IAM access control](https://docs.aws.amazon.com/msk/latest/developerguide/configure-clients-for-iam-access-control.html)
+for the Amazon MSK broker and IAM policy requirements.
 
 ### Confluent Cloud
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -262,24 +262,19 @@ credentials to Kaskade.
 See [Configure clients for IAM access control](https://docs.aws.amazon.com/msk/latest/developerguide/configure-clients-for-iam-access-control.html)
 for the Amazon MSK broker and IAM policy requirements.
 
-#### Required IAM authorization policy
+#### IAM permissions
 
-Amazon MSK IAM authentication does not use Apache Kafka ACLs for authorization.
-Kafka ACLs have no effect on IAM identities; attach an IAM policy to the user or
-role whose credentials Kaskade discovers.
-
-Kaskade operations require these `kafka-cluster` actions:
+The IAM principal used by `--aws` needs these `kafka-cluster` actions:
 
 | Mode | Required actions |
 | --- | --- |
-| Admin browsing | `Connect`, `DescribeTopic`, `DescribeTopicDynamicConfiguration`, `DescribeGroup` |
-| Admin topic changes | Admin browsing plus `CreateTopic`, `AlterTopic`, `DeleteTopic`, `AlterTopicDynamicConfiguration` |
+| Admin (read only) | `Connect`, `DescribeTopic`, `DescribeTopicDynamicConfiguration`, `DescribeGroup` |
+| Admin (full access) | Read-only actions plus `CreateTopic`, `AlterTopic`, `DeleteTopic`, `AlterTopicDynamicConfiguration` |
 | Consumer | `Connect`, `DescribeTopic`, `ReadData`, `DescribeGroup`, `AlterGroup` |
 | Sandbox population | `Connect`, `CreateTopic`, `DescribeTopic`, `WriteData` |
 
-The following policy enables all Kaskade admin and consumer features. Replace the
-region, account, cluster name, and cluster UUID placeholders. Narrow the topic
-wildcard when Kaskade should only access selected topics.
+This policy enables all admin and consumer features. Replace the placeholders
+and narrow the topic wildcard when appropriate.
 
 ```json
 {
@@ -321,16 +316,11 @@ wildcard when Kaskade should only access selected topics.
 }
 ```
 
-Consumer mode creates an ephemeral group named `kaskade-<uuid>`, which is why
-`AlterGroup` can be limited to the `kaskade-*` group ARN. Admin mode needs
-`DescribeGroup` on every group it should display. For read-only admin access,
-remove `CreateTopic`, `AlterTopic`, `DeleteTopic`, and
-`AlterTopicDynamicConfiguration`. For consumer-only access, retain `Connect`,
-`DescribeTopic`, `ReadData`, `DescribeGroup`, and `AlterGroup` on the corresponding
-cluster, topic, and `kaskade-*` group resources.
+Consumer group access can be limited to `kaskade-*` because Kaskade creates
+ephemeral groups named `kaskade-<uuid>`. For read-only admin access, remove the
+topic create, alter, delete, and configuration-alter actions.
 
-The sandbox population command creates topics and writes records, so use this
-separate policy when populating MSK:
+Use this policy for sandbox population:
 
 ```json
 {
@@ -356,34 +346,24 @@ separate policy when populating MSK:
 }
 ```
 
-Schema Registry authorization is separate from Amazon MSK IAM authorization.
 See AWS's [authorization action semantics](https://docs.aws.amazon.com/msk/latest/developerguide/kafka-actions.html)
 and [common client policy use cases](https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control-use-cases.html)
-for action dependencies and resource formats.
+for dependencies and resource formats.
 
-#### Apache Kafka ACLs for SASL/SCRAM and mTLS
+### Kafka ACLs
 
-Keep the IAM policies above when Kaskade connects with `--aws region=<region>`.
-Use Apache Kafka ACLs instead when the broker authenticates Kaskade with
-SASL/SCRAM or mutual TLS. On Amazon MSK, Kafka ACLs do not authorize IAM
-identities, and IAM policies do not replace the ACLs needed by a SCRAM or mTLS
-principal.
-
-Grant the authenticated Kafka principal the operations used by the selected
-Kaskade mode:
+For SASL/SCRAM and mTLS connections, grant the Kafka principal these operations:
 
 | Mode | Topic ACLs | Group ACLs | Cluster ACLs |
 | --- | --- | --- | --- |
-| Admin browsing | `Describe`, `DescribeConfigs` | `Describe` on groups to display | `Describe` |
-| Admin topic changes | Admin browsing plus `Create`, `Alter`, `Delete`, `AlterConfigs` | None beyond admin browsing | None beyond admin browsing |
+| Admin (read only) | `Describe`, `DescribeConfigs` | `Describe` on groups to display | `Describe` |
+| Admin (full access) | `Describe`, `DescribeConfigs`, `Create`, `Alter`, `Delete`, `AlterConfigs` | `Describe` on groups to display | `Describe` |
 | Consumer | `Read`, `Describe` on topics to consume | `Read`, `Describe` on the `kaskade-` prefix | None |
 | Sandbox population | `Create`, `Write`, `Describe` on topics to populate | None | None |
 
-For SASL/SCRAM, the principal is normally `User:<username>`. For mTLS, use the
-principal derived from the client certificate, such as `User:CN=kaskade`. Run
-the following commands as an ACL administrator, replacing the bootstrap servers,
-principal, and command configuration file. The command configuration must contain
-the properties that authenticate `kafka-acls.sh` to the cluster.
+Use `User:<username>` for SASL/SCRAM or the certificate principal for mTLS, such
+as `User:CN=kaskade`. Run the commands as an ACL administrator and configure
+`admin-client.properties` for that administrator.
 
 Full admin access:
 
@@ -455,12 +435,10 @@ kafka-acls.sh \
     --topic '*'
 ```
 
-Replace `--topic '*'` with literal topic names or a prefixed resource pattern
-when broader access is not required. On Amazon MSK,
-`allow.everyone.if.no.acl.found` is `true` by default; after an ACL exists for a
-resource, only explicitly authorized principals can access it. Review AWS's
-[Apache Kafka ACL documentation](https://docs.aws.amazon.com/msk/latest/developerguide/msk-acls.html)
-before applying ACLs to an existing cluster.
+Narrow `--topic '*'` with literal topic names or prefixed resource patterns when
+appropriate. See AWS's
+[Apache Kafka ACL documentation](https://docs.aws.amazon.com/msk/latest/developerguide/msk-acls.html),
+including the default `allow.everyone.if.no.acl.found` behavior.
 
 ### Confluent Cloud
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -262,6 +262,105 @@ credentials to Kaskade.
 See [Configure clients for IAM access control](https://docs.aws.amazon.com/msk/latest/developerguide/configure-clients-for-iam-access-control.html)
 for the Amazon MSK broker and IAM policy requirements.
 
+#### Required IAM authorization policy
+
+Amazon MSK IAM authentication does not use Apache Kafka ACLs for authorization.
+Kafka ACLs have no effect on IAM identities; attach an IAM policy to the user or
+role whose credentials Kaskade discovers.
+
+Kaskade operations require these `kafka-cluster` actions:
+
+| Mode | Required actions |
+| --- | --- |
+| Admin browsing | `Connect`, `DescribeTopic`, `DescribeTopicDynamicConfiguration`, `DescribeGroup` |
+| Admin topic changes | Admin browsing plus `CreateTopic`, `AlterTopic`, `DeleteTopic`, `AlterTopicDynamicConfiguration` |
+| Consumer | `Connect`, `DescribeTopic`, `ReadData`, `DescribeGroup`, `AlterGroup` |
+| Sandbox population | `Connect`, `CreateTopic`, `DescribeTopic`, `WriteData` |
+
+The following policy enables all Kaskade admin and consumer features. Replace the
+region, account, cluster name, and cluster UUID placeholders. Narrow the topic
+wildcard when Kaskade should only access selected topics.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ConnectToCluster",
+      "Effect": "Allow",
+      "Action": "kafka-cluster:Connect",
+      "Resource": "arn:aws:kafka:<region>:<account-id>:cluster/<cluster-name>/<cluster-uuid>"
+    },
+    {
+      "Sid": "ManageAndReadTopics",
+      "Effect": "Allow",
+      "Action": [
+        "kafka-cluster:CreateTopic",
+        "kafka-cluster:DescribeTopic",
+        "kafka-cluster:AlterTopic",
+        "kafka-cluster:DeleteTopic",
+        "kafka-cluster:DescribeTopicDynamicConfiguration",
+        "kafka-cluster:AlterTopicDynamicConfiguration",
+        "kafka-cluster:ReadData"
+      ],
+      "Resource": "arn:aws:kafka:<region>:<account-id>:topic/<cluster-name>/<cluster-uuid>/*"
+    },
+    {
+      "Sid": "InspectConsumerGroups",
+      "Effect": "Allow",
+      "Action": "kafka-cluster:DescribeGroup",
+      "Resource": "arn:aws:kafka:<region>:<account-id>:group/<cluster-name>/<cluster-uuid>/*"
+    },
+    {
+      "Sid": "UseKaskadeConsumerGroups",
+      "Effect": "Allow",
+      "Action": "kafka-cluster:AlterGroup",
+      "Resource": "arn:aws:kafka:<region>:<account-id>:group/<cluster-name>/<cluster-uuid>/kaskade-*"
+    }
+  ]
+}
+```
+
+Consumer mode creates an ephemeral group named `kaskade-<uuid>`, which is why
+`AlterGroup` can be limited to the `kaskade-*` group ARN. Admin mode needs
+`DescribeGroup` on every group it should display. For read-only admin access,
+remove `CreateTopic`, `AlterTopic`, `DeleteTopic`, and
+`AlterTopicDynamicConfiguration`. For consumer-only access, retain `Connect`,
+`DescribeTopic`, `ReadData`, `DescribeGroup`, and `AlterGroup` on the corresponding
+cluster, topic, and `kaskade-*` group resources.
+
+The sandbox population command creates topics and writes records, so use this
+separate policy when populating MSK:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ConnectToCluster",
+      "Effect": "Allow",
+      "Action": "kafka-cluster:Connect",
+      "Resource": "arn:aws:kafka:<region>:<account-id>:cluster/<cluster-name>/<cluster-uuid>"
+    },
+    {
+      "Sid": "CreateAndPopulateTopics",
+      "Effect": "Allow",
+      "Action": [
+        "kafka-cluster:CreateTopic",
+        "kafka-cluster:DescribeTopic",
+        "kafka-cluster:WriteData"
+      ],
+      "Resource": "arn:aws:kafka:<region>:<account-id>:topic/<cluster-name>/<cluster-uuid>/*"
+    }
+  ]
+}
+```
+
+Schema Registry authorization is separate from Amazon MSK IAM authorization.
+See AWS's [authorization action semantics](https://docs.aws.amazon.com/msk/latest/developerguide/kafka-actions.html)
+and [common client policy use cases](https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control-use-cases.html)
+for action dependencies and resource formats.
+
 ### Confluent Cloud
 
 Admin:

--- a/USAGE.md
+++ b/USAGE.md
@@ -361,6 +361,107 @@ See AWS's [authorization action semantics](https://docs.aws.amazon.com/msk/lates
 and [common client policy use cases](https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control-use-cases.html)
 for action dependencies and resource formats.
 
+#### Apache Kafka ACLs for SASL/SCRAM and mTLS
+
+Keep the IAM policies above when Kaskade connects with `--aws region=<region>`.
+Use Apache Kafka ACLs instead when the broker authenticates Kaskade with
+SASL/SCRAM or mutual TLS. On Amazon MSK, Kafka ACLs do not authorize IAM
+identities, and IAM policies do not replace the ACLs needed by a SCRAM or mTLS
+principal.
+
+Grant the authenticated Kafka principal the operations used by the selected
+Kaskade mode:
+
+| Mode | Topic ACLs | Group ACLs | Cluster ACLs |
+| --- | --- | --- | --- |
+| Admin browsing | `Describe`, `DescribeConfigs` | `Describe` on groups to display | `Describe` |
+| Admin topic changes | Admin browsing plus `Create`, `Alter`, `Delete`, `AlterConfigs` | None beyond admin browsing | None beyond admin browsing |
+| Consumer | `Read`, `Describe` on topics to consume | `Read`, `Describe` on the `kaskade-` prefix | None |
+| Sandbox population | `Create`, `Write`, `Describe` on topics to populate | None | None |
+
+For SASL/SCRAM, the principal is normally `User:<username>`. For mTLS, use the
+principal derived from the client certificate, such as `User:CN=kaskade`. Run
+the following commands as an ACL administrator, replacing the bootstrap servers,
+principal, and command configuration file. The command configuration must contain
+the properties that authenticate `kafka-acls.sh` to the cluster.
+
+Full admin access:
+
+```bash
+kafka-acls.sh \
+    --bootstrap-server "${BOOTSTRAP_SERVERS}" \
+    --command-config admin-client.properties \
+    --add \
+    --allow-principal "User:<principal>" \
+    --operation Describe \
+    --cluster
+
+kafka-acls.sh \
+    --bootstrap-server "${BOOTSTRAP_SERVERS}" \
+    --command-config admin-client.properties \
+    --add \
+    --allow-principal "User:<principal>" \
+    --operation Describe \
+    --operation DescribeConfigs \
+    --operation Create \
+    --operation Alter \
+    --operation Delete \
+    --operation AlterConfigs \
+    --topic '*'
+
+kafka-acls.sh \
+    --bootstrap-server "${BOOTSTRAP_SERVERS}" \
+    --command-config admin-client.properties \
+    --add \
+    --allow-principal "User:<principal>" \
+    --operation Describe \
+    --group '*'
+```
+
+Consumer access to one topic and Kaskade's ephemeral consumer groups:
+
+```bash
+kafka-acls.sh \
+    --bootstrap-server "${BOOTSTRAP_SERVERS}" \
+    --command-config admin-client.properties \
+    --add \
+    --allow-principal "User:<principal>" \
+    --operation Read \
+    --operation Describe \
+    --topic '<topic-name>'
+
+kafka-acls.sh \
+    --bootstrap-server "${BOOTSTRAP_SERVERS}" \
+    --command-config admin-client.properties \
+    --add \
+    --allow-principal "User:<principal>" \
+    --operation Read \
+    --operation Describe \
+    --group kaskade- \
+    --resource-pattern-type prefixed
+```
+
+Sandbox population access to all topics:
+
+```bash
+kafka-acls.sh \
+    --bootstrap-server "${BOOTSTRAP_SERVERS}" \
+    --command-config admin-client.properties \
+    --add \
+    --allow-principal "User:<principal>" \
+    --operation Create \
+    --operation Write \
+    --operation Describe \
+    --topic '*'
+```
+
+Replace `--topic '*'` with literal topic names or a prefixed resource pattern
+when broader access is not required. On Amazon MSK,
+`allow.everyone.if.no.acl.found` is `true` by default; after an ACL exists for a
+resource, only explicitly authorized principals can access it. Review AWS's
+[Apache Kafka ACL documentation](https://docs.aws.amazon.com/msk/latest/developerguide/msk-acls.html)
+before applying ACLs to an existing cluster.
+
 ### Confluent Cloud
 
 Admin:

--- a/examples/kafka.properties
+++ b/examples/kafka.properties
@@ -1,5 +1,6 @@
 # Kafka client properties passed to confluent-kafka.
 # Kaskade sets bootstrap.servers from -b/--bootstrap-servers.
+# Amazon MSK IAM authentication is configured separately with --aws region=<region>.
 
 security.protocol=SASL_SSL
 sasl.mechanism=PLAIN

--- a/kaskade/admin.py
+++ b/kaskade/admin.py
@@ -11,6 +11,7 @@ from textual.containers import Container
 from textual.content import Content
 from textual.validation import Function, Integer
 from textual.widgets import (
+    Collapsible,
     DataTable,
     Footer,
     Input,
@@ -76,6 +77,10 @@ def _valid_topic_name(name: str) -> bool:
             for character in name
         )
     )
+
+
+def _valid_optional_positive_integer(value: str) -> bool:
+    return not value or (value.isdigit() and int(value) >= 1)
 
 
 def _input_failures(inputs: dict[str, Input]) -> list[str]:
@@ -375,7 +380,14 @@ class EditTopicScreen(HelpableModalScreen[UpdateTopicCommand]):
             id="min_insync_replicas",
             type="integer",
             value=self.min_insync_replicas,
-            validators=Integer(minimum=1),
+            validators=(
+                Integer(minimum=1)
+                if self.min_insync_replicas
+                else Function(
+                    _valid_optional_positive_integer,
+                    "Enter a positive integer or leave empty when unavailable",
+                )
+            ),
             classes="kaskade-input",
         )
         input_min_insync.border_title = "Min In-Sync Replicas"
@@ -397,7 +409,6 @@ class EditTopicScreen(HelpableModalScreen[UpdateTopicCommand]):
 
         with container:
             yield input_partitions
-            yield input_min_insync
             yield input_retention
             with radio_set:
                 yield RadioButton(
@@ -408,6 +419,8 @@ class EditTopicScreen(HelpableModalScreen[UpdateTopicCommand]):
                     str(CleanupPolicy.COMPACT),
                     value=self.cleanup_policy == str(CleanupPolicy.COMPACT),
                 )
+            with Collapsible(title="Advanced", id="advanced-topic-config"):
+                yield input_min_insync
         yield Footer(compact=True)
 
     def action_edit(self) -> None:
@@ -418,22 +431,42 @@ class EditTopicScreen(HelpableModalScreen[UpdateTopicCommand]):
         }
         failures = _input_failures(inputs)
         if failures:
+            if inputs["Min In-Sync Replicas"].has_class("-invalid"):
+                self.query_one("#advanced-topic-config", Collapsible).collapsed = False
             _focus_first_invalid(inputs)
             self.notify("\n".join(failures), title="Invalid Topic", severity="warning")
             return
 
         cleanup_input = self.query_one("#cleanup", RadioSet)
-        cleanup_policy = (
+        selected_cleanup_policy = (
             str(cleanup_input.pressed_button.label)
             if cleanup_input.pressed_button is not None
-            else str(CleanupPolicy.DELETE)
+            else None
         )
+        cleanup_policy = (
+            selected_cleanup_policy if selected_cleanup_policy != self.cleanup_policy else None
+        )
+
+        min_insync_value = inputs["Min In-Sync Replicas"].value
+        min_insync_replicas = (
+            int(min_insync_value)
+            if min_insync_value
+            and (
+                not self.min_insync_replicas
+                or int(min_insync_value) != int(self.min_insync_replicas)
+            )
+            else None
+        )
+
+        retention_ms = int(inputs["Retention"].value)
+        changed_retention_ms = retention_ms if retention_ms != int(self.retention) else None
+
         self.dismiss(
             UpdateTopicCommand(
                 partitions=int(inputs["Partitions"].value),
-                min_insync_replicas=int(inputs["Min In-Sync Replicas"].value),
+                min_insync_replicas=min_insync_replicas,
                 cleanup_policy=cleanup_policy,
-                retention_ms=int(inputs["Retention"].value),
+                retention_ms=changed_retention_ms,
             )
         )
 
@@ -486,17 +519,23 @@ class CreateTopicScreen(HelpableModalScreen[CreateTopicCommand]):
         input_replication = Input(
             id="replicas",
             type="integer",
-            value="3",
-            validators=Integer(minimum=1),
+            placeholder="Broker default",
+            validators=Function(
+                _valid_optional_positive_integer,
+                "Enter a positive integer or leave empty to use the broker default",
+            ),
             classes="kaskade-input",
         )
-        input_replication.border_title = "Replicas"
+        input_replication.border_title = "Replication Factor"
 
         input_min_insync = Input(
             id="min_insync_replicas",
             type="integer",
-            value="2",
-            validators=Integer(minimum=1),
+            placeholder="Broker default",
+            validators=Function(
+                _valid_optional_positive_integer,
+                "Enter a positive integer or leave empty to use the broker default",
+            ),
             classes="kaskade-input",
         )
         input_min_insync.border_title = "Min In-Sync Replicas"
@@ -519,31 +558,39 @@ class CreateTopicScreen(HelpableModalScreen[CreateTopicCommand]):
         with container:
             yield input_name
             yield input_partitions
-            yield input_replication
-            yield input_min_insync
             yield input_retention
             with radio_set:
                 yield RadioButton(str(CleanupPolicy.DELETE), value=True)
                 yield RadioButton(str(CleanupPolicy.COMPACT))
+            with Collapsible(title="Advanced", id="advanced-topic-config"):
+                yield input_replication
+                yield input_min_insync
         yield Footer(compact=True)
 
     def action_create(self) -> None:
         inputs = {
             "Name": self.query_one("#name", Input),
             "Partitions": self.query_one("#partitions", Input),
-            "Replicas": self.query_one("#replicas", Input),
+            "Replication Factor": self.query_one("#replicas", Input),
             "Min In-Sync Replicas": self.query_one("#min_insync_replicas", Input),
             "Retention": self.query_one("#retention", Input),
         }
         failures = _input_failures(inputs)
 
-        replicas = inputs["Replicas"]
+        replicas = inputs["Replication Factor"]
         min_insync_replicas = inputs["Min In-Sync Replicas"]
-        if not failures and int(min_insync_replicas.value) > int(replicas.value):
+        if (
+            not failures
+            and replicas.value
+            and min_insync_replicas.value
+            and int(min_insync_replicas.value) > int(replicas.value)
+        ):
             min_insync_replicas.add_class("-invalid")
-            failures.append("Min In-Sync Replicas cannot exceed Replicas")
+            failures.append("Min In-Sync Replicas cannot exceed Replication Factor")
 
         if failures:
+            if replicas.has_class("-invalid") or min_insync_replicas.has_class("-invalid"):
+                self.query_one("#advanced-topic-config", Collapsible).collapsed = False
             _focus_first_invalid(inputs)
             self.notify("\n".join(failures), title="Invalid Topic", severity="warning")
             return
@@ -558,8 +605,10 @@ class CreateTopicScreen(HelpableModalScreen[CreateTopicCommand]):
         command = CreateTopicCommand(
             name=inputs["Name"].value,
             partitions=int(inputs["Partitions"].value),
-            replicas=int(replicas.value),
-            min_insync_replicas=int(min_insync_replicas.value),
+            replicas=int(replicas.value) if replicas.value else None,
+            min_insync_replicas=(
+                int(min_insync_replicas.value) if min_insync_replicas.value else None
+            ),
             cleanup_policy=cleanup,
             retention_ms=int(inputs["Retention"].value),
         )
@@ -897,21 +946,35 @@ class ListTopics(Container):
                 partitions_added = True
                 refresh_after = True
 
-            await make_it_async(
-                self.topic_service.edit,
-                topic.name,
-                {
-                    MIN_INSYNC_REPLICAS_CONFIG: str(command.min_insync_replicas),
-                    CLEANUP_POLICY_CONFIG: command.cleanup_policy,
-                    RETENTION_MS_CONFIG: str(command.retention_ms),
-                },
-            )
+            changed_config: dict[str, str] = {}
+            if command.min_insync_replicas is not None:
+                changed_config[MIN_INSYNC_REPLICAS_CONFIG] = str(command.min_insync_replicas)
+            if command.cleanup_policy is not None:
+                changed_config[CLEANUP_POLICY_CONFIG] = command.cleanup_policy
+            if command.retention_ms is not None:
+                changed_config[RETENTION_MS_CONFIG] = str(command.retention_ms)
+
+            if changed_config:
+                await make_it_async(
+                    self.topic_service.edit,
+                    topic.name,
+                    changed_config,
+                )
+                refresh_after = True
+
+            if not refresh_after:
+                self.app.notify(
+                    f"No changes to topic '{topic.name}'",
+                    title="No Changes",
+                    severity="information",
+                )
+                return
+
             self.app.notify(
                 f"Updated topic '{topic.name}'",
                 title="Topic Updated",
                 severity="information",
             )
-            refresh_after = True
         except (KafkaException, ValueError) as ex:
             title = "Topic Partially Updated" if partitions_added else "Kafka Error"
             notify_error(self.app, title, ex)

--- a/kaskade/authentication.py
+++ b/kaskade/authentication.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import Any, cast
+
+SECURITY_PROTOCOL = "security.protocol"
+SASL_MECHANISM = "sasl.mechanism"
+OAUTH_CALLBACK = "oauth_cb"
+SASL_SSL = "SASL_SSL"
+OAUTHBEARER = "OAUTHBEARER"
+
+
+def generate_aws_msk_auth_token(region: str) -> tuple[str, int]:
+    from aws_msk_iam_sasl_signer import MSKAuthTokenProvider  # type: ignore[import-untyped]
+
+    return cast(tuple[str, int], MSKAuthTokenProvider.generate_auth_token(region))
+
+
+@dataclass(frozen=True)
+class AwsMskOAuthCallback:
+    region: str
+
+    def __call__(self, _: str) -> tuple[str, float]:
+        token, expiration_ms = generate_aws_msk_auth_token(self.region)
+        return token, expiration_ms / 1000
+
+
+def configure_aws_msk_iam(config: dict[str, Any], aws_config: dict[str, str]) -> dict[str, Any]:
+    if not aws_config:
+        return config
+
+    region = aws_config["region"]
+    return config | {
+        SECURITY_PROTOCOL: SASL_SSL,
+        SASL_MECHANISM: OAUTHBEARER,
+        OAUTH_CALLBACK: AwsMskOAuthCallback(region),
+    }

--- a/kaskade/cli_utils.py
+++ b/kaskade/cli_utils.py
@@ -1,0 +1,23 @@
+from click import BadParameter, Context, MissingParameter, Parameter
+
+from kaskade.configs import AWS_CONFIGS
+
+
+def tuple_properties_to_dict(
+    ctx: Context, param: Parameter | None, value: tuple[str, ...]
+) -> dict[str, str]:
+    if [pair for pair in value if "=" not in pair]:
+        raise BadParameter(message="Should be property=value.", ctx=ctx, param=param)
+
+    return {key: item for key, item in [pair.split("=", 1) for pair in value]}
+
+
+def validate_aws_config(aws_config: dict[str, str]) -> None:
+    if not aws_config:
+        return
+
+    if [config for config in aws_config if config not in AWS_CONFIGS]:
+        raise BadParameter(message=f"Valid properties: {AWS_CONFIGS}.")
+
+    if not aws_config.get("region"):
+        raise MissingParameter(param_hint="'--aws region=my-region'", param_type="option")

--- a/kaskade/commands.py
+++ b/kaskade/commands.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 class CreateTopicCommand:
     name: str
     partitions: int
-    replicas: int
-    min_insync_replicas: int
+    replicas: int | None
+    min_insync_replicas: int | None
     cleanup_policy: str
     retention_ms: int
 
@@ -14,9 +14,9 @@ class CreateTopicCommand:
 @dataclass(frozen=True)
 class UpdateTopicCommand:
     partitions: int
-    min_insync_replicas: int
-    cleanup_policy: str
-    retention_ms: int
+    min_insync_replicas: int | None
+    cleanup_policy: str | None
+    retention_ms: int | None
 
 
 @dataclass(frozen=True)

--- a/kaskade/configs.py
+++ b/kaskade/configs.py
@@ -20,6 +20,7 @@ SCHEMA_REGISTRY_CONFIGS = [
 PROTOBUF_DESERIALIZER_CONFIGS = ["descriptor", "key", "value"]
 AVRO_DESERIALIZER_CONFIGS = ["key", "value", "framing"]
 AVRO_FRAMINGS = ["raw", "confluent"]
+AWS_CONFIGS = ["region"]
 SCHEMA_REGISTRY_MAGIC_BYTE = 0
 BOOTSTRAP_SERVERS = "bootstrap.servers"
 AUTO_OFFSET_RESET = "auto.offset.reset"

--- a/kaskade/consumer.py
+++ b/kaskade/consumer.py
@@ -313,7 +313,7 @@ class ListRecords(Container):
     def __init__(
         self,
         topic: str,
-        kafka_config: dict[str, str],
+        kafka_config: dict[str, Any],
         deserializer_factory: DeserializerPool,
         key_deserialization: Deserialization,
         value_deserialization: Deserialization,
@@ -565,7 +565,7 @@ class KaskadeConsumer(KaskadeApp):
     def __init__(
         self,
         topic: str,
-        kafka_config: dict[str, str],
+        kafka_config: dict[str, Any],
         registry_config: dict[str, str],
         protobuf_config: dict[str, str],
         avro_config: dict[str, str],

--- a/kaskade/main.py
+++ b/kaskade/main.py
@@ -10,6 +10,7 @@ from confluent_kafka import KafkaException
 from kaskade import APP_VERSION
 from kaskade.admin import KaskadeAdmin
 from kaskade.authentication import configure_aws_msk_iam
+from kaskade.cli_utils import tuple_properties_to_dict, validate_aws_config
 from kaskade.configs import (
     AUTO_OFFSET_RESET,
     AVRO_DESERIALIZER_CONFIGS,
@@ -55,13 +56,6 @@ AWS_CONFIG_HELP = (
     f"Valid properties: {AWS_CONFIGS}."
 )
 CliDecoratorTarget = TypeVar("CliDecoratorTarget", bound=Callable[..., Any])
-
-
-def tuple_properties_to_dict(ctx: Any, param: Any, value: Any) -> Any:
-    if [pair for pair in value if "=" not in pair]:
-        raise BadParameter(message="Should be property=value.", ctx=ctx, param=param)
-
-    return {k: v for (k, v) in [pair.split("=", 1) for pair in value]}
 
 
 def aws_options() -> Callable[[CliDecoratorTarget], CliDecoratorTarget]:
@@ -209,7 +203,7 @@ def admin(
         kafka_config = load_properties(kafka_config_file) | kafka_config
 
     kafka_config[BOOTSTRAP_SERVERS] = bootstrap_servers
-    validate_aws(aws_config)
+    validate_aws_config(aws_config)
     kafka_config = configure_aws_msk_iam(kafka_config, aws_config)
 
     kaskade_app = KaskadeAdmin(kafka_config, refresh_interval=refresh_interval)
@@ -371,7 +365,7 @@ def consumer(
         kafka_config = load_properties(kafka_config_file) | kafka_config
 
     kafka_config[BOOTSTRAP_SERVERS] = bootstrap_servers
-    validate_aws(aws_config)
+    validate_aws_config(aws_config)
     kafka_config = configure_aws_msk_iam(kafka_config, aws_config)
 
     if earliest and partitions:
@@ -435,17 +429,6 @@ def validate_deserializer(
         or value_deserialization == Deserialization.PROTOBUF
     ):
         raise MissingParameter(param_hint="'--protobuf'", param_type="option")
-
-
-def validate_aws(aws_config: dict[str, str]) -> None:
-    if not aws_config:
-        return
-
-    if [config for config in aws_config if config not in AWS_CONFIGS]:
-        raise BadParameter(message=f"Valid properties: {AWS_CONFIGS}.")
-
-    if not aws_config.get("region"):
-        raise MissingParameter(param_hint="'--aws region=my-region'", param_type="option")
 
 
 def validate_avro(

--- a/kaskade/main.py
+++ b/kaskade/main.py
@@ -1,6 +1,7 @@
 import re
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 import cloup
 from click import BadParameter, ClickException, MissingParameter
@@ -8,10 +9,12 @@ from confluent_kafka import KafkaException
 
 from kaskade import APP_VERSION
 from kaskade.admin import KaskadeAdmin
+from kaskade.authentication import configure_aws_msk_iam
 from kaskade.configs import (
     AUTO_OFFSET_RESET,
     AVRO_DESERIALIZER_CONFIGS,
     AVRO_FRAMINGS,
+    AWS_CONFIGS,
     BOOTSTRAP_SERVERS,
     EARLIEST,
     PROTOBUF_DESERIALIZER_CONFIGS,
@@ -47,6 +50,11 @@ PARTITION_SELECTION_HELP = (
 PARTITION_SELECTION_PATTERN = re.compile(
     rf"(?P<partition>[0-9]+)(?::(?P<offset>[0-9]+|{re.escape(EARLIEST)}))?"
 )
+AWS_CONFIG_HELP = (
+    "AWS property. Configure Amazon MSK IAM authentication. Multiple '--aws' are allowed. "
+    f"Valid properties: {AWS_CONFIGS}."
+)
+CliDecoratorTarget = TypeVar("CliDecoratorTarget", bound=Callable[..., Any])
 
 
 def tuple_properties_to_dict(ctx: Any, param: Any, value: Any) -> Any:
@@ -54,6 +62,20 @@ def tuple_properties_to_dict(ctx: Any, param: Any, value: Any) -> Any:
         raise BadParameter(message="Should be property=value.", ctx=ctx, param=param)
 
     return {k: v for (k, v) in [pair.split("=", 1) for pair in value]}
+
+
+def aws_options() -> Callable[[CliDecoratorTarget], CliDecoratorTarget]:
+    return cloup.option_group(
+        "AWS options",
+        cloup.option(
+            "--aws",
+            "aws_config",
+            help=AWS_CONFIG_HELP,
+            metavar="property=value",
+            multiple=True,
+            callback=tuple_properties_to_dict,
+        ),
+    )
 
 
 def string_to_deserializer_type(ctx: Any, param: Any, value: Any) -> Any:
@@ -162,10 +184,12 @@ def cli() -> None:
         metavar="filename",
     ),
 )
+@aws_options()
 def admin(
     bootstrap_servers: str,
     kafka_config_file: str | None,
-    kafka_config: dict[str, str],
+    kafka_config: dict[str, Any],
+    aws_config: dict[str, str],
     theme: str,
     refresh_interval: int | None,
 ) -> None:
@@ -178,12 +202,15 @@ def admin(
       kaskade admin -b localhost:9092 --refresh-interval 10
       kaskade admin -b localhost:9092 --config security.protocol=SSL
       kaskade admin -b localhost:9092 --config-file kafka.properties
+      kaskade admin -b localhost:9092 --aws region=us-east-1
     """
 
     if kafka_config_file is not None:
         kafka_config = load_properties(kafka_config_file) | kafka_config
 
     kafka_config[BOOTSTRAP_SERVERS] = bootstrap_servers
+    validate_aws(aws_config)
+    kafka_config = configure_aws_msk_iam(kafka_config, aws_config)
 
     kaskade_app = KaskadeAdmin(kafka_config, refresh_interval=refresh_interval)
     kaskade_app.theme = theme
@@ -231,6 +258,7 @@ def admin(
         metavar="filename",
     ),
 )
+@aws_options()
 @cloup.option_group(
     "Topic options",
     cloup.option(
@@ -309,7 +337,7 @@ def admin(
 )
 def consumer(
     bootstrap_servers: str,
-    kafka_config: dict[str, str],
+    kafka_config: dict[str, Any],
     registry_config: dict[str, str],
     protobuf_config: dict[str, str],
     avro_config: dict[str, str],
@@ -319,6 +347,7 @@ def consumer(
     earliest: bool,
     partitions: tuple[PartitionSelection, ...],
     kafka_config_file: str | None,
+    aws_config: dict[str, str],
     theme: str,
 ) -> None:
     """
@@ -331,6 +360,7 @@ def consumer(
       kaskade consumer -b localhost:9092 -t my-topic --partition 1:10 --partition 2:earliest
       kaskade consumer -b localhost:9092 -t my-topic --config security.protocol=SSL
       kaskade consumer -b localhost:9092 -t my-topic --config-file kafka.properties
+      kaskade consumer -b localhost:9092 -t my-topic --aws region=us-east-1
       kaskade consumer -b localhost:9092 -t my-topic -v json
       kaskade consumer -b localhost:9092 -t my-topic -v registry --registry url=http://localhost:8081
       kaskade consumer -b localhost:9092 -t my-topic -v avro --avro value=my-schema.avsc
@@ -341,6 +371,8 @@ def consumer(
         kafka_config = load_properties(kafka_config_file) | kafka_config
 
     kafka_config[BOOTSTRAP_SERVERS] = bootstrap_servers
+    validate_aws(aws_config)
+    kafka_config = configure_aws_msk_iam(kafka_config, aws_config)
 
     if earliest and partitions:
         raise BadParameter(
@@ -403,6 +435,17 @@ def validate_deserializer(
         or value_deserialization == Deserialization.PROTOBUF
     ):
         raise MissingParameter(param_hint="'--protobuf'", param_type="option")
+
+
+def validate_aws(aws_config: dict[str, str]) -> None:
+    if not aws_config:
+        return
+
+    if [config for config in aws_config if config not in AWS_CONFIGS]:
+        raise BadParameter(message=f"Valid properties: {AWS_CONFIGS}.")
+
+    if not aws_config.get("region"):
+        raise MissingParameter(param_hint="'--aws region=my-region'", param_type="option")
 
 
 def validate_avro(

--- a/kaskade/services.py
+++ b/kaskade/services.py
@@ -71,7 +71,7 @@ class ConsumerService:
     def __init__(
         self,
         topic: str,
-        kafka_config: dict[str, str],
+        kafka_config: dict[str, Any],
         deserializer_factory: DeserializerPool,
         key_deserialization: Deserialization,
         value_deserialization: Deserialization,
@@ -347,9 +347,7 @@ class GroupSnapshot:
 class TopicService:
     GROUP_OFFSET_CONCURRENCY = 16
 
-    def __init__(
-        self, config: dict[str, str | int | float | bool], *, timeout: float = 2.0
-    ) -> None:
+    def __init__(self, config: dict[str, Any], *, timeout: float = 2.0) -> None:
         self.timeout = timeout
         self.config = config.copy()
         self.admin_client = AdminClient(self.config, logger=logger)

--- a/kaskade/services.py
+++ b/kaskade/services.py
@@ -353,15 +353,18 @@ class TopicService:
         self.admin_client = AdminClient(self.config, logger=logger)
 
     def create(self, command: CreateTopicCommand) -> None:
+        topic_config = {
+            CLEANUP_POLICY_CONFIG: command.cleanup_policy,
+            RETENTION_MS_CONFIG: str(command.retention_ms),
+        }
+        if command.min_insync_replicas is not None:
+            topic_config[MIN_INSYNC_REPLICAS_CONFIG] = str(command.min_insync_replicas)
+
         new_topic = NewTopic(
             topic=command.name,
             num_partitions=command.partitions,
-            replication_factor=command.replicas,
-            config={
-                CLEANUP_POLICY_CONFIG: command.cleanup_policy,
-                RETENTION_MS_CONFIG: str(command.retention_ms),
-                MIN_INSYNC_REPLICAS_CONFIG: str(command.min_insync_replicas),
-            },
+            replication_factor=command.replicas if command.replicas is not None else -1,
+            config=topic_config,
         )
         futures = self.admin_client.create_topics([new_topic])
         for future in futures.values():

--- a/kaskade/styles.css
+++ b/kaskade/styles.css
@@ -123,6 +123,10 @@ DeleteTopicScreen > Input {
     padding: 0 1;
 }
 
+.topic-form {
+    overflow-y: auto;
+}
+
 Input.kaskade-input {
     padding: 0 0 0 1;
     border: solid $secondary 50%;

--- a/kaskade/widgets.py
+++ b/kaskade/widgets.py
@@ -20,7 +20,7 @@ class KaskadeHeader(Horizontal):
     def __init__(self, kafka_config: Mapping[str, Any], *, version: str = APP_VERSION) -> None:
         super().__init__(id="kaskade-header")
         bootstrap_servers = kafka_config.get(BOOTSTRAP_SERVERS, "Not configured")
-        self.bootstrap_servers = str(bootstrap_servers)
+        self.bootstrap_servers = str(bootstrap_servers).split(",", maxsplit=1)[0].strip()
         self.version = version
 
     def _product_text(self) -> Text:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 requires-python = ">=3.10,<3.15"
 dependencies = [
+    "aws-msk-iam-sasl-signer-python>=1.0",
     "cloup>=3.1",
     "fastavro>=1.12",
     "textual>=8.2",

--- a/sandbox/__main__.py
+++ b/sandbox/__main__.py
@@ -39,7 +39,13 @@ MALFORMED_PAYLOAD_BYTES = 32
 
 
 class Populator:
-    def __init__(self, kafka_config: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        kafka_config: dict[str, Any],
+        partitions: int = 10,
+        replication_factor: int | None = None,
+        min_insync_replicas: int | None = None,
+    ) -> None:
         self.producer = Producer(
             kafka_config
             | {
@@ -47,15 +53,22 @@ class Populator:
             }
         )
         self.admin_client = AdminClient(kafka_config)
+        self.partitions = partitions
+        self.replication_factor = replication_factor
+        self.min_insync_replicas = min_insync_replicas
 
     def create_topic(self, topic: str) -> None:
+        topic_config = {}
+        if self.min_insync_replicas is not None:
+            topic_config[MIN_INSYNC_REPLICAS_CONFIG] = str(self.min_insync_replicas)
+
         new_topic = NewTopic(
             topic=topic,
-            num_partitions=10,
-            replication_factor=3,
-            config={
-                MIN_INSYNC_REPLICAS_CONFIG: "2",
-            },
+            num_partitions=self.partitions,
+            replication_factor=(
+                self.replication_factor if self.replication_factor is not None else -1
+            ),
+            config=topic_config,
         )
         futures = self.admin_client.create_topics([new_topic])
         for future in futures.values():
@@ -137,6 +150,25 @@ def sandbox_kafka_config(bootstrap_servers: str, aws_config: dict[str, str]) -> 
 @click.command()
 @click.option("--messages", default=1000, help="Number of messages to send.")
 @click.option(
+    "--partitions",
+    type=click.IntRange(min=1),
+    default=10,
+    help="Number of partitions for created topics.",
+    show_default=True,
+)
+@click.option(
+    "--replication-factor",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Replication factor for created topics. Uses the broker default when omitted.",
+)
+@click.option(
+    "--min-insync-replicas",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Minimum in-sync replicas for created topics. Uses the broker default when omitted.",
+)
+@click.option(
     "--bootstrap-servers", default="localhost:19092", help="Bootstrap servers.", show_default=True
 )
 @click.option(
@@ -155,6 +187,9 @@ def sandbox_kafka_config(bootstrap_servers: str, aws_config: dict[str, str]) -> 
 )
 def main(
     messages: int,
+    partitions: int,
+    replication_factor: int | None,
+    min_insync_replicas: int | None,
     bootstrap_servers: str,
     registry: str,
     aws_config: dict[str, str],
@@ -248,7 +283,12 @@ def main(
             ),
         ),
     ]
-    populator = Populator(kafka_config)
+    populator = Populator(
+        kafka_config,
+        partitions=partitions,
+        replication_factor=replication_factor,
+        min_insync_replicas=min_insync_replicas,
+    )
     console = Console()
     with console.status("", spinner="dots") as status:
         for topic, generator, serializer in topics:

--- a/sandbox/__main__.py
+++ b/sandbox/__main__.py
@@ -20,7 +20,9 @@ from faker import Faker
 from rich.console import Console
 from rich.status import Status
 
-from kaskade.configs import BOOTSTRAP_SERVERS, MIN_INSYNC_REPLICAS_CONFIG
+from kaskade.authentication import configure_aws_msk_iam
+from kaskade.cli_utils import tuple_properties_to_dict, validate_aws_config
+from kaskade.configs import AWS_CONFIGS, BOOTSTRAP_SERVERS, MIN_INSYNC_REPLICAS_CONFIG
 from kaskade.utils import file_to_str, pack_bytes, py_to_avro
 from sandbox.avro_model.user import User as AvroUser
 from sandbox.json_model.user import User as JsonUser
@@ -37,7 +39,7 @@ MALFORMED_PAYLOAD_BYTES = 32
 
 
 class Populator:
-    def __init__(self, kafka_config: dict[str, str | int | float | bool]) -> None:
+    def __init__(self, kafka_config: dict[str, Any]) -> None:
         self.producer = Producer(
             kafka_config
             | {
@@ -127,6 +129,11 @@ def run_population(
     console.print(f":white_check_mark: {topic} [green]{time.time() - start:.1f} secs[/]")
 
 
+def sandbox_kafka_config(bootstrap_servers: str, aws_config: dict[str, str]) -> dict[str, Any]:
+    validate_aws_config(aws_config)
+    return configure_aws_msk_iam({BOOTSTRAP_SERVERS: bootstrap_servers}, aws_config)
+
+
 @click.command()
 @click.option("--messages", default=1000, help="Number of messages to send.")
 @click.option(
@@ -138,7 +145,21 @@ def run_population(
     help="Schema registry. For Apicurio use 'http://localhost:18082/apis/ccompat/v7'",
     show_default=True,
 )
-def main(messages: int, bootstrap_servers: str, registry: str) -> None:
+@click.option(
+    "--aws",
+    "aws_config",
+    help=f"Amazon MSK IAM property. Multiple are allowed. Valid properties: {AWS_CONFIGS}.",
+    metavar="property=value",
+    multiple=True,
+    callback=tuple_properties_to_dict,
+)
+def main(
+    messages: int,
+    bootstrap_servers: str,
+    registry: str,
+    aws_config: dict[str, str],
+) -> None:
+    kafka_config = sandbox_kafka_config(bootstrap_servers, aws_config)
     registry_client = SchemaRegistryClient({"url": registry})
     avro_serializer = AvroSerializer(
         registry_client,
@@ -227,7 +248,7 @@ def main(messages: int, bootstrap_servers: str, registry: str) -> None:
             ),
         ),
     ]
-    populator = Populator({BOOTSTRAP_SERVERS: bootstrap_servers})
+    populator = Populator(kafka_config)
     console = Console()
     with console.status("", spinner="dots") as status:
         for topic, generator, serializer in topics:

--- a/sandbox/__main__.py
+++ b/sandbox/__main__.py
@@ -32,6 +32,22 @@ SANDBOX_PATH = Path(__file__).resolve().parent
 JSON_USER_SCHEMA = str(SANDBOX_PATH / "json_model" / "user.schema.json")
 AVRO_USER_SCHEMA = str(SANDBOX_PATH / "avro_model" / "user.avsc")
 ERRORS_TOPIC = "errors"
+AVAILABLE_TOPICS = (
+    "string",
+    "integer",
+    "long",
+    "float",
+    "double",
+    "boolean",
+    "null",
+    "json",
+    "json-schema",
+    "protobuf",
+    "protobuf-schema",
+    "avro",
+    "avro-schema",
+    ERRORS_TOPIC,
+)
 ERROR_CASES = ("key", "value", "both", "valid")
 MALFORMED_KEY_CASES = frozenset({"key", "both"})
 MALFORMED_VALUE_CASES = frozenset({"value", "both"})
@@ -147,8 +163,24 @@ def sandbox_kafka_config(bootstrap_servers: str, aws_config: dict[str, str]) -> 
     return configure_aws_msk_iam({BOOTSTRAP_SERVERS: bootstrap_servers}, aws_config)
 
 
+def validate_topics(
+    ctx: click.Context, param: click.Parameter, value: tuple[str, ...]
+) -> tuple[str, ...] | None:
+    if len(value) != len(set(value)):
+        raise click.BadParameter("Each topic may only be selected once.", ctx=ctx, param=param)
+    return value or None
+
+
 @click.command()
 @click.option("--messages", default=1000, help="Number of messages to send.")
+@click.option(
+    "--topic",
+    "selected_topics",
+    type=click.Choice(AVAILABLE_TOPICS),
+    multiple=True,
+    callback=validate_topics,
+    help="Topic to populate. Repeat for a subset; omit to populate all topics.",
+)
 @click.option(
     "--partitions",
     type=click.IntRange(min=1),
@@ -187,6 +219,7 @@ def sandbox_kafka_config(bootstrap_servers: str, aws_config: dict[str, str]) -> 
 )
 def main(
     messages: int,
+    selected_topics: tuple[str, ...] | None,
     partitions: int,
     replication_factor: int | None,
     min_insync_replicas: int | None,
@@ -210,103 +243,111 @@ def main(
         ProtobufUser, registry_client, {"use.deprecated.format": False}
     )
     faker = Faker()
-    topics = [
-        (
-            "string",
-            lambda: faker.name(),
-            lambda value: value.encode("utf-8"),
-        ),
-        (
-            "integer",
-            lambda: faker.pyint(min_value=500, max_value=10000),
-            lambda value: pack_bytes(">i", value),
-        ),
-        (
-            "long",
-            lambda: faker.pyint(min_value=500, max_value=10000),
-            lambda value: pack_bytes(">q", value),
-        ),
-        (
-            "float",
-            lambda: faker.pyfloat(min_value=500, max_value=10000),
-            lambda value: pack_bytes(">f", value),
-        ),
-        (
-            "double",
-            lambda: faker.pyfloat(min_value=500, max_value=10000),
-            lambda value: pack_bytes(">d", value),
-        ),
-        (
-            "boolean",
-            lambda: faker.pybool(),
-            lambda value: pack_bytes(">?", value),
-        ),
-        (
-            "null",
-            lambda: "not null" if faker.pybool() else None,
-            lambda value: value.encode("utf-8") if value else None,
-        ),
-        (
-            "json",
-            lambda: faker.json(),
-            lambda value: value.encode("utf-8"),
-        ),
-        (
-            "json-schema",
-            lambda: JsonUser(name=faker.name()),
-            lambda value: json_serializer(
-                value, SerializationContext("json-schema", MessageField.VALUE)
-            ),
-        ),
-        (
-            "protobuf",
-            lambda: ProtobufUser(name=faker.name()),
-            lambda value: value.SerializeToString(),
-        ),
-        (
-            "protobuf-schema",
-            lambda: ProtobufUser(name=faker.name()),
-            lambda value: protobuf_serializer(
-                value, SerializationContext("protobuf-schema", MessageField.VALUE)
-            ),
-        ),
-        (
-            "avro",
-            lambda: AvroUser(name=faker.name()),
-            lambda value: py_to_avro(AVRO_USER_SCHEMA, vars(value)),
-        ),
-        (
-            "avro-schema",
-            lambda: AvroUser(name=faker.name()),
-            lambda value: avro_serializer(
-                value, SerializationContext("avro-schema", MessageField.VALUE)
-            ),
-        ),
-    ]
     populator = Populator(
         kafka_config,
         partitions=partitions,
         replication_factor=replication_factor,
         min_insync_replicas=min_insync_replicas,
     )
+
+    def topic_population(
+        topic: str,
+        generator: Callable[[], Any],
+        serializer: Callable[[Any], Any],
+    ) -> tuple[str, Callable[[], None]]:
+        return topic, partial(populator.populate, topic, generator, serializer, messages)
+
+    topics: list[tuple[str, Callable[[], None]]] = [
+        topic_population(
+            "string",
+            lambda: faker.name(),
+            lambda value: value.encode("utf-8"),
+        ),
+        topic_population(
+            "integer",
+            lambda: faker.pyint(min_value=500, max_value=10000),
+            lambda value: pack_bytes(">i", value),
+        ),
+        topic_population(
+            "long",
+            lambda: faker.pyint(min_value=500, max_value=10000),
+            lambda value: pack_bytes(">q", value),
+        ),
+        topic_population(
+            "float",
+            lambda: faker.pyfloat(min_value=500, max_value=10000),
+            lambda value: pack_bytes(">f", value),
+        ),
+        topic_population(
+            "double",
+            lambda: faker.pyfloat(min_value=500, max_value=10000),
+            lambda value: pack_bytes(">d", value),
+        ),
+        topic_population(
+            "boolean",
+            lambda: faker.pybool(),
+            lambda value: pack_bytes(">?", value),
+        ),
+        topic_population(
+            "null",
+            lambda: "not null" if faker.pybool() else None,
+            lambda value: value.encode("utf-8") if value else None,
+        ),
+        topic_population(
+            "json",
+            lambda: faker.json(),
+            lambda value: value.encode("utf-8"),
+        ),
+        topic_population(
+            "json-schema",
+            lambda: JsonUser(name=faker.name()),
+            lambda value: json_serializer(
+                value, SerializationContext("json-schema", MessageField.VALUE)
+            ),
+        ),
+        topic_population(
+            "protobuf",
+            lambda: ProtobufUser(name=faker.name()),
+            lambda value: value.SerializeToString(),
+        ),
+        topic_population(
+            "protobuf-schema",
+            lambda: ProtobufUser(name=faker.name()),
+            lambda value: protobuf_serializer(
+                value, SerializationContext("protobuf-schema", MessageField.VALUE)
+            ),
+        ),
+        topic_population(
+            "avro",
+            lambda: AvroUser(name=faker.name()),
+            lambda value: py_to_avro(AVRO_USER_SCHEMA, vars(value)),
+        ),
+        topic_population(
+            "avro-schema",
+            lambda: AvroUser(name=faker.name()),
+            lambda value: avro_serializer(
+                value, SerializationContext("avro-schema", MessageField.VALUE)
+            ),
+        ),
+        (
+            ERRORS_TOPIC,
+            partial(populator.populate_registry_errors, json_serializer, faker, messages),
+        ),
+    ]
+    if selected_topics is not None:
+        actions_by_topic = dict(topics)
+        topics = [(topic, actions_by_topic[topic]) for topic in selected_topics]
+
     console = Console()
     with console.status("", spinner="dots") as status:
-        for topic, generator, serializer in topics:
+        for topic, action in topics:
             run_population(
                 console,
                 status,
                 populator,
                 topic,
-                partial(populator.populate, topic, generator, serializer, messages),
+                action,
             )
-
-        run_population(
-            console,
-            status,
-            populator,
-            ERRORS_TOPIC,
-            partial(populator.populate_registry_errors, json_serializer, faker, messages),
-        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/tests_admin.py
+++ b/tests/unit/tests_admin.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from confluent_kafka import KafkaException
-from textual.widgets import DataTable, Input
+from textual.widgets import Collapsible, DataTable, Input, RadioButton, RadioSet
 
 from kaskade.admin import (
     CreateTopicScreen,
@@ -19,6 +19,7 @@ from kaskade.admin import (
     RefreshReason,
 )
 from kaskade.commands import CreateTopicCommand, UpdateTopicCommand
+from kaskade.configs import MIN_INSYNC_REPLICAS_CONFIG
 from kaskade.keymaps import CONFIG_ENV_VAR
 from kaskade.models import MetricState, Partition, Topic
 from kaskade.services import EnrichmentResult, GroupSnapshot
@@ -64,6 +65,28 @@ class TestRefreshCoordinator(unittest.TestCase):
 
 
 class TestCreateTopic(unittest.IsolatedAsyncioTestCase):
+    async def test_uses_broker_defaults_for_advanced_replication_settings(self) -> None:
+        with patch("kaskade.admin.TopicService") as topic_service:
+            configure_admin_service(topic_service.return_value, {})
+            app = KaskadeAdmin({})
+            results: list[CreateTopicCommand | None] = []
+
+            async with app.run_test() as pilot:
+                app.push_screen(CreateTopicScreen(), results.append)
+                await pilot.pause()
+
+                advanced = app.screen.query_one("#advanced-topic-config", Collapsible)
+                self.assertTrue(advanced.collapsed)
+                self.assertEqual("", app.screen.query_one("#replicas", Input).value)
+                self.assertEqual("", app.screen.query_one("#min_insync_replicas", Input).value)
+
+                app.screen.query_one("#name", Input).value = "orders"
+                await pilot.press("ctrl+s")
+
+                self.assertEqual(1, len(results))
+                self.assertIsNone(results[0].replicas)
+                self.assertIsNone(results[0].min_insync_replicas)
+
     async def test_keeps_invalid_topic_configuration_open(self) -> None:
         with patch("kaskade.admin.TopicService") as topic_service:
             configure_admin_service(topic_service.return_value, {})
@@ -118,6 +141,114 @@ class TestCreateTopic(unittest.IsolatedAsyncioTestCase):
 
 
 class TestUpdateTopic(unittest.IsolatedAsyncioTestCase):
+    async def test_keeps_unchanged_topic_configuration_out_of_command(self) -> None:
+        app = KaskadeAdmin({})
+        results: list[UpdateTopicCommand | None] = []
+
+        with patch("kaskade.admin.TopicService") as topic_service:
+            configure_admin_service(topic_service.return_value, {})
+            async with app.run_test() as pilot:
+                app.push_screen(
+                    EditTopicScreen("orders", "3", "2", "delete", "1000"), results.append
+                )
+                await pilot.pause()
+
+                advanced = app.screen.query_one("#advanced-topic-config", Collapsible)
+                self.assertTrue(advanced.collapsed)
+                self.assertEqual("2", app.screen.query_one("#min_insync_replicas", Input).value)
+
+                await pilot.press("ctrl+s")
+
+                self.assertEqual(
+                    UpdateTopicCommand(3, None, None, None),
+                    results[0],
+                )
+
+    async def test_includes_only_changed_topic_configuration_in_command(self) -> None:
+        cases = (
+            ("min_insync", UpdateTopicCommand(3, 1, None, None)),
+            ("cleanup", UpdateTopicCommand(3, None, "compact", None)),
+            ("retention", UpdateTopicCommand(3, None, None, 2000)),
+        )
+
+        for setting, expected in cases:
+            with self.subTest(setting=setting):
+                app = KaskadeAdmin({})
+                results: list[UpdateTopicCommand | None] = []
+                with patch("kaskade.admin.TopicService") as topic_service:
+                    configure_admin_service(topic_service.return_value, {})
+                    async with app.run_test() as pilot:
+                        app.push_screen(
+                            EditTopicScreen("orders", "3", "2", "delete", "1000"),
+                            results.append,
+                        )
+                        await pilot.pause()
+
+                        if setting == "min_insync":
+                            app.screen.query_one("#min_insync_replicas", Input).value = "1"
+                        elif setting == "cleanup":
+                            cleanup = app.screen.query_one("#cleanup", RadioSet)
+                            cleanup.query(RadioButton)[1].value = True
+                        else:
+                            app.screen.query_one("#retention", Input).value = "2000"
+
+                        await pilot.press("ctrl+s")
+
+                        self.assertEqual(expected, results[0])
+
+    async def test_preserves_unsupported_cleanup_policy_when_unchanged(self) -> None:
+        app = KaskadeAdmin({})
+        results: list[UpdateTopicCommand | None] = []
+
+        with patch("kaskade.admin.TopicService") as topic_service:
+            configure_admin_service(topic_service.return_value, {})
+            async with app.run_test() as pilot:
+                app.push_screen(
+                    EditTopicScreen("orders", "3", "2", "compact,delete", "1000"),
+                    results.append,
+                )
+                await pilot.pause()
+
+                await pilot.press("ctrl+s")
+
+                self.assertEqual(UpdateTopicCommand(3, None, None, None), results[0])
+
+    async def test_expands_advanced_when_min_insync_is_cleared(self) -> None:
+        app = KaskadeAdmin({})
+        results: list[UpdateTopicCommand | None] = []
+
+        with patch("kaskade.admin.TopicService") as topic_service:
+            configure_admin_service(topic_service.return_value, {})
+            async with app.run_test() as pilot:
+                app.push_screen(
+                    EditTopicScreen("orders", "3", "2", "delete", "1000"), results.append
+                )
+                await pilot.pause()
+                app.screen.query_one("#min_insync_replicas", Input).value = ""
+
+                await pilot.press("ctrl+s")
+
+                self.assertEqual([], results)
+                self.assertFalse(
+                    app.screen.query_one("#advanced-topic-config", Collapsible).collapsed
+                )
+
+    async def test_allows_missing_min_insync_to_remain_unchanged(self) -> None:
+        app = KaskadeAdmin({})
+        results: list[UpdateTopicCommand | None] = []
+
+        with patch("kaskade.admin.TopicService") as topic_service:
+            configure_admin_service(topic_service.return_value, {})
+            async with app.run_test() as pilot:
+                app.push_screen(
+                    EditTopicScreen("orders", "3", "", "delete", "1000"), results.append
+                )
+                await pilot.pause()
+
+                await pilot.press("ctrl+s")
+
+                self.assertEqual(UpdateTopicCommand(3, None, None, None), results[0])
+
     async def test_rejects_partition_decreases_before_mutating(self) -> None:
         app = KaskadeAdmin({})
         results: list[UpdateTopicCommand | None] = []
@@ -135,6 +266,74 @@ class TestUpdateTopic(unittest.IsolatedAsyncioTestCase):
 
                 self.assertIsInstance(app.screen, EditTopicScreen)
                 self.assertEqual([], results)
+
+    async def test_skips_kafka_calls_when_topic_is_unchanged(self) -> None:
+        topic = Topic(name="orders", partitions=[Partition(id=0, topic="orders")])
+        service = MagicMock()
+        configure_admin_service(service, {topic.name: topic})
+
+        with patch("kaskade.admin.TopicService", return_value=service):
+            app = KaskadeAdmin({})
+            app.notify = MagicMock()
+            async with app.run_test() as pilot:
+                await app.workers.wait_for_complete()
+                topics = app.query_one(ListTopics)
+                worker = topics.update_topic(
+                    topic,
+                    UpdateTopicCommand(1, None, None, None),
+                )
+                await worker.wait()
+                await pilot.pause()
+
+                service.add_partitions.assert_not_called()
+                service.edit.assert_not_called()
+                app.notify.assert_called_once_with(
+                    "No changes to topic 'orders'",
+                    title="No Changes",
+                    severity="information",
+                )
+
+    async def test_sends_only_changed_topic_configuration(self) -> None:
+        topic = Topic(name="orders", partitions=[Partition(id=0, topic="orders")])
+        service = MagicMock()
+        configure_admin_service(service, {topic.name: topic})
+
+        with patch("kaskade.admin.TopicService", return_value=service):
+            app = KaskadeAdmin({})
+            app.notify = MagicMock()
+            async with app.run_test() as pilot:
+                await app.workers.wait_for_complete()
+                topics = app.query_one(ListTopics)
+                worker = topics.update_topic(
+                    topic,
+                    UpdateTopicCommand(1, 2, None, None),
+                )
+                await worker.wait()
+                await pilot.pause()
+
+                service.add_partitions.assert_not_called()
+                service.edit.assert_called_once_with("orders", {MIN_INSYNC_REPLICAS_CONFIG: "2"})
+
+    async def test_partition_only_update_skips_topic_config_edit(self) -> None:
+        topic = Topic(name="orders", partitions=[Partition(id=0, topic="orders")])
+        service = MagicMock()
+        configure_admin_service(service, {topic.name: topic})
+
+        with patch("kaskade.admin.TopicService", return_value=service):
+            app = KaskadeAdmin({})
+            app.notify = MagicMock()
+            async with app.run_test() as pilot:
+                await app.workers.wait_for_complete()
+                topics = app.query_one(ListTopics)
+                worker = topics.update_topic(
+                    topic,
+                    UpdateTopicCommand(2, None, None, None),
+                )
+                await worker.wait()
+                await pilot.pause()
+
+                service.add_partitions.assert_called_once_with("orders", 2)
+                service.edit.assert_not_called()
 
     async def test_refreshes_after_partial_topic_update(self) -> None:
         topic = Topic(name="orders", partitions=[Partition(id=0, topic="orders")])

--- a/tests/unit/tests_authentication.py
+++ b/tests/unit/tests_authentication.py
@@ -1,0 +1,45 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from kaskade.authentication import (
+    OAUTH_CALLBACK,
+    OAUTHBEARER,
+    SASL_MECHANISM,
+    SASL_SSL,
+    SECURITY_PROTOCOL,
+    AwsMskOAuthCallback,
+    configure_aws_msk_iam,
+)
+
+
+class TestAwsMskAuthentication(unittest.TestCase):
+    def test_leaves_config_unchanged_without_region(self) -> None:
+        config = {"bootstrap.servers": "localhost:9092"}
+
+        result = configure_aws_msk_iam(config, {})
+
+        self.assertIs(config, result)
+
+    def test_configures_iam_authentication(self) -> None:
+        result = configure_aws_msk_iam(
+            {
+                "bootstrap.servers": "broker:9098",
+                SECURITY_PROTOCOL: "PLAINTEXT",
+                SASL_MECHANISM: "PLAIN",
+            },
+            {"region": "us-east-1"},
+        )
+
+        self.assertEqual(SASL_SSL, result[SECURITY_PROTOCOL])
+        self.assertEqual(OAUTHBEARER, result[SASL_MECHANISM])
+        self.assertEqual(AwsMskOAuthCallback("us-east-1"), result[OAUTH_CALLBACK])
+
+    @patch("kaskade.authentication.generate_aws_msk_auth_token")
+    def test_callback_converts_expiration_to_seconds(self, mock_generate: MagicMock) -> None:
+        mock_generate.return_value = ("token", 1_725_000_000_000)
+
+        token, expiration = AwsMskOAuthCallback("us-west-2")("ignored")
+
+        self.assertEqual("token", token)
+        self.assertEqual(1_725_000_000, expiration)
+        mock_generate.assert_called_once_with("us-west-2")

--- a/tests/unit/tests_main.py
+++ b/tests/unit/tests_main.py
@@ -5,6 +5,14 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 
+from kaskade.authentication import (
+    OAUTH_CALLBACK,
+    OAUTHBEARER,
+    SASL_MECHANISM,
+    SASL_SSL,
+    SECURITY_PROTOCOL,
+    AwsMskOAuthCallback,
+)
 from kaskade.configs import AUTO_OFFSET_RESET, BOOTSTRAP_SERVERS, EARLIEST
 from kaskade.deserializers import Deserialization
 from kaskade.main import PARTITION_SELECTION_METAVAR, cli
@@ -36,6 +44,38 @@ class TestAdminCli(unittest.TestCase):
         self.assertIn(
             "Invalid value for '-c' / '--config': Should be property=value", result.output
         )
+
+    def test_invalid_aws_config(self):
+        result = self.runner.invoke(cli, [self.command, "--aws", "region"])
+
+        self.assertGreater(result.exit_code, 0)
+        self.assertIn("Invalid value for '--aws': Should be property=value", result.output)
+
+    def test_rejects_unknown_aws_config(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                self.command,
+                "-b",
+                EXPECTED_SERVER,
+                "--aws",
+                "profile=example",
+                "--aws",
+                "region=us-east-1",
+            ],
+        )
+
+        self.assertGreater(result.exit_code, 0)
+        self.assertIn("Invalid value: Valid properties: ['region']", result.output)
+
+    def test_requires_aws_region_value(self):
+        result = self.runner.invoke(
+            cli,
+            [self.command, "-b", EXPECTED_SERVER, "--aws", "region="],
+        )
+
+        self.assertGreater(result.exit_code, 0)
+        self.assertIn("Missing option '--aws region=my-region'", result.output)
 
     @patch("kaskade.main.KaskadeAdmin")
     def test_update_kafka_config(self, mock_class_kaskade_admin):
@@ -186,6 +226,27 @@ class TestAdminCli(unittest.TestCase):
             },
             refresh_interval=None,
         )
+        self.assertEqual(0, result.exit_code)
+
+    @patch("kaskade.main.KaskadeAdmin")
+    def test_configures_aws_msk_iam_authentication(self, mock_class_kaskade_admin):
+        result = self.runner.invoke(
+            cli,
+            [
+                self.command,
+                "-b",
+                EXPECTED_SERVER,
+                "-c",
+                f"{SECURITY_PROTOCOL}=PLAINTEXT",
+                "--aws",
+                "region=us-east-1",
+            ],
+        )
+
+        config = mock_class_kaskade_admin.call_args.args[0]
+        self.assertEqual(SASL_SSL, config[SECURITY_PROTOCOL])
+        self.assertEqual(OAUTHBEARER, config[SASL_MECHANISM])
+        self.assertEqual(AwsMskOAuthCallback("us-east-1"), config[OAUTH_CALLBACK])
         self.assertEqual(0, result.exit_code)
 
 
@@ -711,6 +772,27 @@ class TestConsumerCli(unittest.TestCase):
             Deserialization.BYTES,
             Deserialization.BYTES,
         )
+        self.assertEqual(0, result.exit_code)
+
+    @patch("kaskade.main.KaskadeConsumer")
+    def test_configures_aws_msk_iam_authentication(self, mock_class_kaskade_consumer):
+        result = self.runner.invoke(
+            cli,
+            [
+                self.command,
+                "-b",
+                EXPECTED_SERVER,
+                "-t",
+                EXPECTED_TOPIC,
+                "--aws",
+                "region=us-west-2",
+            ],
+        )
+
+        config = mock_class_kaskade_consumer.call_args.args[1]
+        self.assertEqual(SASL_SSL, config[SECURITY_PROTOCOL])
+        self.assertEqual(OAUTHBEARER, config[SASL_MECHANISM])
+        self.assertEqual(AwsMskOAuthCallback("us-west-2"), config[OAUTH_CALLBACK])
         self.assertEqual(0, result.exit_code)
 
     @patch("kaskade.main.KaskadeConsumer")

--- a/tests/unit/tests_sandbox.py
+++ b/tests/unit/tests_sandbox.py
@@ -13,7 +13,7 @@ from kaskade.authentication import (
     AwsMskOAuthCallback,
 )
 from kaskade.configs import BOOTSTRAP_SERVERS
-from sandbox.__main__ import Populator, main, sandbox_kafka_config
+from sandbox.__main__ import AVAILABLE_TOPICS, ERRORS_TOPIC, Populator, main, sandbox_kafka_config
 
 
 class TestPopulator(unittest.TestCase):
@@ -104,7 +104,7 @@ class TestSandboxKafkaConfig(unittest.TestCase):
     @patch("sandbox.__main__.run_population")
     @patch("sandbox.__main__.Populator")
     def test_cli_passes_topic_settings_to_populator(
-        self, mock_populator: MagicMock, _: MagicMock
+        self, mock_populator: MagicMock, mock_run_population: MagicMock
     ) -> None:
         result = CliRunner().invoke(
             main,
@@ -129,3 +129,34 @@ class TestSandboxKafkaConfig(unittest.TestCase):
             },
             mock_populator.call_args.kwargs,
         )
+        self.assertEqual(14, mock_run_population.call_count)
+        self.assertEqual(ERRORS_TOPIC, mock_run_population.call_args.args[3])
+
+    @patch("sandbox.__main__.run_population")
+    @patch("sandbox.__main__.Populator")
+    def test_cli_populates_only_selected_topics(
+        self, _: MagicMock, mock_run_population: MagicMock
+    ) -> None:
+        result = CliRunner().invoke(
+            main,
+            ["--messages", "0", "--topic", "string", "--topic", ERRORS_TOPIC],
+        )
+
+        self.assertEqual(0, result.exit_code, result.output)
+        self.assertEqual(
+            ["string", ERRORS_TOPIC],
+            [call.args[3] for call in mock_run_population.call_args_list],
+        )
+
+    def test_cli_rejects_unknown_topic(self) -> None:
+        result = CliRunner().invoke(main, ["--topic", "unknown"])
+
+        self.assertNotEqual(0, result.exit_code)
+        self.assertIn("Invalid value for '--topic'", result.output)
+        self.assertIn(AVAILABLE_TOPICS[0], result.output)
+
+    def test_cli_rejects_duplicate_topic(self) -> None:
+        result = CliRunner().invoke(main, ["--topic", "string", "--topic", "string"])
+
+        self.assertNotEqual(0, result.exit_code)
+        self.assertIn("Each topic may only be selected once", result.output)

--- a/tests/unit/tests_sandbox.py
+++ b/tests/unit/tests_sandbox.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import click
+from click.testing import CliRunner
+
+from kaskade.authentication import (
+    OAUTH_CALLBACK,
+    OAUTHBEARER,
+    SASL_MECHANISM,
+    SASL_SSL,
+    SECURITY_PROTOCOL,
+    AwsMskOAuthCallback,
+)
+from kaskade.configs import BOOTSTRAP_SERVERS
+from sandbox.__main__ import main, sandbox_kafka_config
+
+
+class TestSandboxKafkaConfig(unittest.TestCase):
+    def test_preserves_local_kafka_config_without_aws_properties(self) -> None:
+        config = sandbox_kafka_config("localhost:19092", {})
+
+        self.assertEqual({BOOTSTRAP_SERVERS: "localhost:19092"}, config)
+
+    def test_configures_aws_msk_iam_authentication(self) -> None:
+        config = sandbox_kafka_config("broker:9098", {"region": "us-east-1"})
+
+        self.assertEqual("broker:9098", config[BOOTSTRAP_SERVERS])
+        self.assertEqual(SASL_SSL, config[SECURITY_PROTOCOL])
+        self.assertEqual(OAUTHBEARER, config[SASL_MECHANISM])
+        self.assertEqual(AwsMskOAuthCallback("us-east-1"), config[OAUTH_CALLBACK])
+
+    def test_rejects_unknown_aws_config(self) -> None:
+        with self.assertRaisesRegex(click.BadParameter, "Valid properties"):
+            sandbox_kafka_config("broker:9098", {"profile": "example", "region": "us-east-1"})
+
+    def test_requires_aws_region_value(self) -> None:
+        with self.assertRaises(click.MissingParameter) as raised:
+            sandbox_kafka_config("broker:9098", {"region": ""})
+
+        self.assertEqual("'--aws region=my-region'", raised.exception.param_hint)
+
+    @patch("sandbox.__main__.run_population")
+    @patch("sandbox.__main__.Populator")
+    def test_cli_passes_aws_config_to_populator(
+        self, mock_populator: MagicMock, _: MagicMock
+    ) -> None:
+        result = CliRunner().invoke(
+            main,
+            [
+                "--messages",
+                "0",
+                "--bootstrap-servers",
+                "broker:9098",
+                "--aws",
+                "region=us-west-2",
+            ],
+        )
+
+        self.assertEqual(0, result.exit_code, result.output)
+        config = mock_populator.call_args.args[0]
+        self.assertEqual(AwsMskOAuthCallback("us-west-2"), config[OAUTH_CALLBACK])

--- a/tests/unit/tests_sandbox.py
+++ b/tests/unit/tests_sandbox.py
@@ -13,7 +13,39 @@ from kaskade.authentication import (
     AwsMskOAuthCallback,
 )
 from kaskade.configs import BOOTSTRAP_SERVERS
-from sandbox.__main__ import main, sandbox_kafka_config
+from sandbox.__main__ import Populator, main, sandbox_kafka_config
+
+
+class TestPopulator(unittest.TestCase):
+    @patch("sandbox.__main__.Producer")
+    @patch("sandbox.__main__.AdminClient")
+    def test_create_topic_uses_broker_replication_defaults(
+        self, mock_admin_client: MagicMock, _: MagicMock
+    ) -> None:
+        mock_admin_client.return_value.create_topics.return_value = {"orders": MagicMock()}
+
+        Populator({}).create_topic("orders")
+
+        topic = mock_admin_client.return_value.create_topics.call_args.args[0][0]
+        self.assertEqual(10, topic.num_partitions)
+        self.assertEqual(-1, topic.replication_factor)
+        self.assertEqual({}, topic.config)
+
+    @patch("sandbox.__main__.Producer")
+    @patch("sandbox.__main__.AdminClient")
+    def test_create_topic_uses_explicit_replication_settings(
+        self, mock_admin_client: MagicMock, _: MagicMock
+    ) -> None:
+        mock_admin_client.return_value.create_topics.return_value = {"orders": MagicMock()}
+
+        Populator({}, partitions=6, replication_factor=3, min_insync_replicas=2).create_topic(
+            "orders"
+        )
+
+        topic = mock_admin_client.return_value.create_topics.call_args.args[0][0]
+        self.assertEqual(6, topic.num_partitions)
+        self.assertEqual(3, topic.replication_factor)
+        self.assertEqual({"min.insync.replicas": "2"}, topic.config)
 
 
 class TestSandboxKafkaConfig(unittest.TestCase):
@@ -60,3 +92,40 @@ class TestSandboxKafkaConfig(unittest.TestCase):
         self.assertEqual(0, result.exit_code, result.output)
         config = mock_populator.call_args.args[0]
         self.assertEqual(AwsMskOAuthCallback("us-west-2"), config[OAUTH_CALLBACK])
+        self.assertEqual(
+            {
+                "partitions": 10,
+                "replication_factor": None,
+                "min_insync_replicas": None,
+            },
+            mock_populator.call_args.kwargs,
+        )
+
+    @patch("sandbox.__main__.run_population")
+    @patch("sandbox.__main__.Populator")
+    def test_cli_passes_topic_settings_to_populator(
+        self, mock_populator: MagicMock, _: MagicMock
+    ) -> None:
+        result = CliRunner().invoke(
+            main,
+            [
+                "--messages",
+                "0",
+                "--partitions",
+                "6",
+                "--replication-factor",
+                "3",
+                "--min-insync-replicas",
+                "2",
+            ],
+        )
+
+        self.assertEqual(0, result.exit_code, result.output)
+        self.assertEqual(
+            {
+                "partitions": 6,
+                "replication_factor": 3,
+                "min_insync_replicas": 2,
+            },
+            mock_populator.call_args.kwargs,
+        )

--- a/tests/unit/tests_services.py
+++ b/tests/unit/tests_services.py
@@ -107,6 +107,20 @@ class TestTopicService(unittest.IsolatedAsyncioTestCase):
             new_topic.config,
         )
 
+    @patch("kaskade.services.AdminClient")
+    async def test_create_topic_uses_broker_replication_defaults(
+        self, mock_class_admin: MagicMock
+    ) -> None:
+        admin = mock_class_admin.return_value
+        admin.create_topics.return_value = {"orders": completed(None)}
+        command = CreateTopicCommand("orders", 3, None, None, "delete", 1000)
+
+        TopicService({"bootstrap.servers": "localhost:9092"}).create(command)
+
+        new_topic = admin.create_topics.call_args.args[0][0]
+        self.assertEqual(-1, new_topic.replication_factor)
+        self.assertEqual({"cleanup.policy": "delete", "retention.ms": "1000"}, new_topic.config)
+
     @patch("kaskade.services.Consumer")
     @patch("kaskade.services.AdminClient")
     async def test_batches_offsets_without_admin_consumers(

--- a/tests/unit/tests_themes.py
+++ b/tests/unit/tests_themes.py
@@ -574,7 +574,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                     header.query_one("#kaskade-product", Static).render().plain,
                 )
                 self.assertEqual(
-                    bootstrap_servers,
+                    "kafka1:9092",
                     header.query_one("#kaskade-kafka", Static).render().plain,
                 )
                 self.assertIsInstance(table, StretchyDataTable)
@@ -602,7 +602,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 kafka = header.query_one("#kaskade-kafka", Static)
 
                 self.assertEqual(f"Kaskade v{APP_VERSION}", product.render().plain)
-                self.assertEqual(bootstrap_servers, kafka.render().plain)
+                self.assertEqual("[::1]:9092", kafka.render().plain)
                 self.assertEqual(3, header.region.height)
                 self.assertEqual(app.screen.content_region.width, header.region.width)
                 self.assertEqual(

--- a/uv.lock
+++ b/uv.lock
@@ -302,6 +302,20 @@ wheels = [
 ]
 
 [[package]]
+name = "aws-msk-iam-sasl-signer-python"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/8b/9af0a7def4ba357afadc89c06019d3735944cb3d6065a455f41580ba7fd6/aws_msk_iam_sasl_signer_python-1.0.2.tar.gz", hash = "sha256:3432d88a7c6db4887ceb1130ebaed0113bfda48b79ea811537add5f1d25fa13f", size = 24034, upload-time = "2025-03-05T20:49:48.582Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/43/f3ffd79fc4941b8d610530d81e1f600cfa1b8651affc25cb929fd0f2f2c9/aws_msk_iam_sasl_signer_python-1.0.2-py2.py3-none-any.whl", hash = "sha256:310eb2db9ca0ff55ed06a24212739b87533e7f1cf6f34e43aabbd97a3b21290e", size = 13279, upload-time = "2025-03-05T20:49:46.611Z" },
+]
+
+[[package]]
 name = "black"
 version = "26.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -343,6 +357,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
     { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
     { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.84"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/e1/a714560efabf44b22ed94a537593be76aec87b7a655830d951431e04fe26/boto3-1.43.84.tar.gz", hash = "sha256:973e9982a3a819644c71d7fe4f9e67b4f833d33760ba418c2a0680aa5afed1f0", size = 112756, upload-time = "2026-08-31T19:26:59.516Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/ee/0aa69f63752dcd99a2f2832883dbc1c50c2e157172c00b2243413d3d5f0f/boto3-1.43.84-py3-none-any.whl", hash = "sha256:4d46d5689b82d05c3a1ed6de285c1f8f05cceffd5eec930a5423105ee6a9e0d1", size = 140026, upload-time = "2026-08-31T19:26:56.889Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.85"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/93/a8b3acb06fcbb440704f195dbf14d12bb83c9c9d67b2e699076017f3d5c6/botocore-1.43.85.tar.gz", hash = "sha256:8fc0a3c56078c629320b021edadf7a45d289eea21a4988ada6a02277e5bbbdc0", size = 16040188, upload-time = "2026-08-31T23:23:48.929Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/4b/bb053aec2a9902df4cdbf9301dd5a41dd197c1cef0c085a32f5d04eeb3e3/botocore-1.43.85-py3-none-any.whl", hash = "sha256:685510e5f4c0f321806c815a60f121a176c0969665f053c4a336209cbe62b1d5", size = 15732946, upload-time = "2026-08-31T23:23:45.927Z" },
 ]
 
 [[package]]
@@ -1042,6 +1084,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "joserfc"
 version = "1.7.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1085,6 +1136,7 @@ wheels = [
 name = "kaskade"
 source = { editable = "." }
 dependencies = [
+    { name = "aws-msk-iam-sasl-signer-python" },
     { name = "cloup" },
     { name = "confluent-kafka", extra = ["avro", "json", "protobuf"] },
     { name = "fastavro" },
@@ -1110,6 +1162,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aws-msk-iam-sasl-signer-python", specifier = ">=1.0" },
     { name = "cloup", specifier = ">=3.1" },
     { name = "confluent-kafka", extras = ["avro", "json", "protobuf"], specifier = ">=2.15" },
     { name = "fastavro", specifier = ">=1.12" },
@@ -1855,6 +1908,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-discovery"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2288,6 +2353,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/20/656d67f5b25ca9bda4e02b1de25867b2954e1d19e03648060f167ad0f4cc/ruff-0.16.5-py3-none-win32.whl", hash = "sha256:288b0a5f080492fe5635db849f9e2e84aa3cce7b7f0e955997d416c507c76a26", size = 10034250, upload-time = "2026-08-27T16:34:11.8Z" },
     { url = "https://files.pythonhosted.org/packages/5b/42/ee8e68a207b9127fcde6c3d7e197def432f346cb1af159e1fa14ca0d1cdc/ruff-0.16.5-py3-none-win_amd64.whl", hash = "sha256:ddc6385fb2137f616357ca03d6c74f4be987f80fed4008566b754f6032b8546f", size = 10516714, upload-time = "2026-08-27T16:34:13.963Z" },
     { url = "https://files.pythonhosted.org/packages/73/e3/7df5a396e445b9ba49ce9a9437439a4d80042c61c0ade199abf8d16de1ac/ruff-0.16.5-py3-none-win_arm64.whl", hash = "sha256:a64abe90968719b851bb7cedffaa8753fbdbdadab483089682db623f3edc587e", size = 10391564, upload-time = "2026-08-27T16:34:16.064Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add AWS MSK IAM authentication to admin and consumer modes through repeatable
`--aws property=value` configuration. Configure librdkafka for
SASL/OAUTHBEARER and refresh signer tokens using the standard AWS credential
chain.

Extend the sandbox population tool with the same AWS MSK IAM configuration.
Document the IAM permissions and Kafka ACLs needed by admin, consumer, and
sandbox operations.

Closes #44

Assisted-by: Codex GPT-5
