### PR TITLE
fix(tui): keep table frame visible while loading

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -156,6 +156,8 @@ Help is a dedicated centered `ModalScreen`, not a sidebar. It must:
 
 - Keep all application styling in the shared `kaskade/styles.css`; both admin
   and consumer applications inherit `KaskadeApp.CSS_PATH`.
+- Keep main-table borders, titles, and subtitles on the shared `TableFrame` so
+  a table's loading indicator replaces only its content inside the frame.
 - Keep the shared one-line root header on both main applications: show the
   Kaskade version on the left and only Kafka `bootstrap.servers` on the right.
   Give the name and version contrasting semantic colors, and truncate the Kafka

--- a/kaskade/admin.py
+++ b/kaskade/admin.py
@@ -41,7 +41,7 @@ from kaskade.services import (
 from kaskade.themes import KaskadeApp
 from kaskade.unicodes import APPROXIMATION
 from kaskade.utils import copy_text, make_it_async, notify_error
-from kaskade.widgets import KaskadeHeader, StretchyDataTable
+from kaskade.widgets import KaskadeHeader, StretchyDataTable, TableFrame
 
 REFRESH_TABLE_DELAY = 1
 FILTER_TOPICS_SHORTCUT = "/,ctrl+f"
@@ -731,12 +731,8 @@ class ListTopics(Container):
         self.refresh_coordinator = RefreshCoordinator()
 
     def compose(self) -> ComposeResult:
-        table: StretchyDataTable[str] = StretchyDataTable(
-            id="topics-table", classes="kaskade-table main-table"
-        )
+        table: StretchyDataTable[str] = StretchyDataTable(id="topics-table", classes="main-table")
         table.cursor_type = "row"
-        table.border_title = rf"[{PRIMARY}]Topics[/] \[[{PRIMARY}]0[/]]"
-        table.border_subtitle = rf"\[[{PRIMARY}]Admin Mode[/]]"
         table.zebra_stripes = True
 
         table.add_column("Name", key="name", stretch=1)
@@ -748,7 +744,10 @@ class ListTopics(Container):
         table.add_column("Records", key="records")
         table.add_column("Lag", key="lag")
 
-        yield table
+        frame = TableFrame(table, id="topics-frame", classes="kaskade-table")
+        frame.border_title = rf"[{PRIMARY}]Topics[/] \[[{PRIMARY}]0[/]]"
+        frame.border_subtitle = rf"\[[{PRIMARY}]Admin Mode[/]]"
+        yield frame
 
     def on_mount(self) -> None:
         table = self.query_one("#topics-table", DataTable)
@@ -1112,7 +1111,7 @@ class ListTopics(Container):
         desired_keys = [topic.name for topic in visible_topics]
         self._render_topic_rows(table, visible_topics, desired_keys, selected_topic_name)
         self._restore_selection(table, desired_keys, selected_topic_name)
-        self._update_table_title(table, len(visible_topics))
+        self._update_table_title(len(visible_topics))
         self.finish_loading_table()
 
     def _visible_topics(self) -> list[Topic]:
@@ -1156,11 +1155,11 @@ class ListTopics(Container):
             self.current_topic = None
         self.refresh_bindings()
 
-    def _update_table_title(self, table: DataTable[Any], visible_topic_count: int) -> None:
+    def _update_table_title(self, visible_topic_count: int) -> None:
         border_title_filter_info = (
             rf"\[[{PRIMARY}]*{self.current_filter}*[/]]" if self.current_filter else ""
         )
-        table.border_title = (
+        self.query_one("#topics-frame", TableFrame).border_title = (
             rf"[{PRIMARY}]Topics[/] {border_title_filter_info}"
             rf"\[[{PRIMARY}]{visible_topic_count}[/]]"
         )
@@ -1189,7 +1188,6 @@ class ListTopics(Container):
         return LOADING_METRIC
 
     def _update_status(self, *, refreshing: bool) -> None:
-        table = self.query_one(DataTable)
         interval = getattr(self.app, "auto_refresh_interval", 0)
         auto_status = f"Auto {interval}s" if interval else "Auto Off"
         if refreshing:
@@ -1198,7 +1196,9 @@ class ListTopics(Container):
             state = f"Updated {self.last_updated_at:%H:%M:%S}"
         else:
             state = "Not Updated"
-        table.border_subtitle = rf"\[[{PRIMARY}]Admin Mode · {state} · {auto_status}[/]]"
+        self.query_one("#topics-frame", TableFrame).border_subtitle = (
+            rf"\[[{PRIMARY}]Admin Mode · {state} · {auto_status}[/]]"
+        )
 
 
 class KaskadeAdmin(KaskadeApp):

--- a/kaskade/consumer.py
+++ b/kaskade/consumer.py
@@ -35,6 +35,7 @@ from kaskade.widgets import (
     KaskadeOptionList,
     KaskadeScrollableContainer,
     StretchyDataTable,
+    TableFrame,
 )
 
 CHUNKS_SHORTCUT = "#"
@@ -365,11 +366,9 @@ class ListRecords(Container):
         return rf"[{PRIMARY}]Records[/] \[[{PRIMARY}]{self.topic}[/]]{title_filter}\[[{PRIMARY}]{len(self.records)}[/]]"
 
     def compose(self) -> ComposeResult:
-        table = RecordDataTable(id="records-table", classes="kaskade-table main-table")
+        table = RecordDataTable(id="records-table", classes="main-table")
         table.cursor_type = "row"
-        table.border_subtitle = rf"\[[{PRIMARY}]Consumer Mode[/]]"
         table.zebra_stripes = True
-        table.border_title = self._get_title()
 
         table.add_column("Key", stretch=2)
         table.add_column("Value", stretch=3)
@@ -378,7 +377,10 @@ class ListRecords(Container):
         table.add_column("Offset", width=9)
         table.add_column("Headers", width=9)
 
-        yield table
+        frame = TableFrame(table, id="records-frame", classes="kaskade-table")
+        frame.border_title = self._get_title()
+        frame.border_subtitle = rf"\[[{PRIMARY}]Consumer Mode[/]]"
+        yield frame
 
     async def on_unmount(self) -> None:
         result = self.consumer.aclose()
@@ -411,8 +413,11 @@ class ListRecords(Container):
         self.records = {}
         self.current_record = None
         self.refresh_bindings()
-        table.border_title = self._get_title()
+        self._update_table_title()
         self.action_consume()
+
+    def _update_table_title(self) -> None:
+        self.query_one("#records-frame", TableFrame).border_title = self._get_title()
 
     def action_change_chunk(self) -> None:
         def dismiss(result: int | None) -> None:
@@ -549,7 +554,7 @@ class ListRecords(Container):
                 row_index = len(table.rows)
                 table.add_row(*self._record_row(record), key=record_id)
                 self._add_warning_tooltips(table, row_index, record)
-            table.border_title = self._get_title()
+            self._update_table_title()
         except CONSUMER_EXCEPTIONS as ex:
             notify_error(self.app, "Consumption Error", ex)
         finally:

--- a/kaskade/styles.css
+++ b/kaskade/styles.css
@@ -38,13 +38,18 @@ DataTable:focus > .datatable--header {
     background-tint: transparent;
 }
 
-DataTable.kaskade-table {
+.kaskade-table {
     border: solid $secondary 50%;
     height: 100%;
 }
 
-DataTable.kaskade-table:focus {
+.kaskade-table:focus-within {
     border: $secondary;
+}
+
+.kaskade-table > DataTable {
+    border: none;
+    height: 100%;
 }
 
 DataTable.details-table {

--- a/kaskade/widgets.py
+++ b/kaskade/widgets.py
@@ -5,7 +5,7 @@ from rich.text import Text, TextType
 from textual import events
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
-from textual.containers import Horizontal, ScrollableContainer
+from textual.containers import Container, Horizontal, ScrollableContainer
 from textual.geometry import Size
 from textual.widgets import DataTable, OptionList, Static
 from textual.widgets.data_table import CellType, ColumnKey
@@ -49,6 +49,10 @@ class KaskadeHeader(Horizontal):
             self._product_text(),
             layout=False,
         )
+
+
+class TableFrame(Container):
+    """Keep table borders and titles visible while table content is loading."""
 
 
 class StretchyDataTable(DataTable[CellType]):

--- a/tests/unit/tests_admin.py
+++ b/tests/unit/tests_admin.py
@@ -23,6 +23,7 @@ from kaskade.configs import MIN_INSYNC_REPLICAS_CONFIG
 from kaskade.keymaps import CONFIG_ENV_VAR
 from kaskade.models import MetricState, Partition, Topic, TopicConfiguration
 from kaskade.services import EnrichmentResult, GroupSnapshot
+from kaskade.widgets import TableFrame
 from tests import configure_admin_service
 
 
@@ -62,6 +63,38 @@ class TestRefreshCoordinator(unittest.TestCase):
 
         self.assertFalse(coordinator.complete(0))
         self.assertTrue(coordinator.is_current(generation or 0))
+
+
+class TestInitialLoadingFrame(unittest.IsolatedAsyncioTestCase):
+    async def test_keeps_topics_frame_visible_while_table_loads(self) -> None:
+        started = asyncio.Event()
+        release = asyncio.Event()
+        service = MagicMock()
+        configure_admin_service(service, {})
+
+        async def metadata() -> dict[str, Topic]:
+            started.set()
+            await release.wait()
+            return {}
+
+        service.metadata = AsyncMock(side_effect=metadata)
+        with patch("kaskade.admin.TopicService", return_value=service):
+            app = KaskadeAdmin({})
+            async with app.run_test() as pilot:
+                try:
+                    await started.wait()
+                    await pilot.pause()
+                    frame = app.query_one("#topics-frame", TableFrame)
+                    table = app.query_one("#topics-table", DataTable)
+
+                    self.assertTrue(table.loading)
+                    self.assertFalse(frame.loading)
+                    self.assertIn("Topics", frame.border_title)
+                    self.assertNotEqual("", frame.styles.border_top[0])
+                    self.assertEqual("", table.styles.border_top[0])
+                finally:
+                    release.set()
+                await app.workers.wait_for_complete()
 
 
 class TestCreateTopic(unittest.IsolatedAsyncioTestCase):
@@ -558,7 +591,10 @@ class TestAdminRefresh(unittest.IsolatedAsyncioTestCase):
 
                     self.assertEqual(0, app.auto_refresh_interval)
                     self.assertIsNone(app._auto_refresh_timer)
-                    self.assertIn("Auto Off", app.query_one(DataTable).border_subtitle)
+                    self.assertIn(
+                        "Auto Off",
+                        app.query_one("#topics-frame", TableFrame).border_subtitle,
+                    )
 
     async def test_renders_metadata_before_metrics_finish(self) -> None:
         offsets_gate = asyncio.Event()

--- a/tests/unit/tests_consumer.py
+++ b/tests/unit/tests_consumer.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from rich.text import Text
 from textual import events
 from textual.coordinate import Coordinate
+from textual.widgets import DataTable
 
 from kaskade.colors import WARNING as WARNING_STYLE
 from kaskade.consumer import (
@@ -26,6 +27,7 @@ from kaskade.models import Header, Record
 from kaskade.record_export import record_filename
 from kaskade.themes import KaskadeApp
 from kaskade.unicodes import WARNING as WARNING_INDICATOR
+from kaskade.widgets import TableFrame
 
 
 def exported_record() -> Record:
@@ -418,6 +420,46 @@ class TestRecordCopyActions(unittest.IsolatedAsyncioTestCase):
 
 
 class TestConsumptionCoordination(unittest.IsolatedAsyncioTestCase):
+    @patch("kaskade.consumer.ConsumerService")
+    async def test_keeps_records_frame_visible_while_table_loads(
+        self, consumer_service: MagicMock
+    ) -> None:
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def consume(*, filters: object) -> list[Record]:
+            started.set()
+            await release.wait()
+            return []
+
+        consumer_service.return_value.consume = AsyncMock(side_effect=consume)
+        consumer_service.return_value.aclose = AsyncMock()
+        app = KaskadeConsumer(
+            "orders",
+            {},
+            {},
+            {},
+            {},
+            Deserialization.STRING,
+            Deserialization.JSON,
+        )
+
+        async with app.run_test() as pilot:
+            try:
+                await started.wait()
+                await pilot.pause()
+                frame = app.query_one("#records-frame", TableFrame)
+                table = app.query_one("#records-table", DataTable)
+
+                self.assertTrue(table.loading)
+                self.assertFalse(frame.loading)
+                self.assertIn("Records", frame.border_title)
+                self.assertNotEqual("", frame.styles.border_top[0])
+                self.assertEqual("", table.styles.border_top[0])
+            finally:
+                release.set()
+            await app.workers.wait_for_complete()
+
     @patch("kaskade.consumer.ConsumerService")
     async def test_warning_record_has_visible_indicator_and_warning_cells(
         self, consumer_service: MagicMock

--- a/tests/unit/tests_themes.py
+++ b/tests/unit/tests_themes.py
@@ -54,6 +54,7 @@ from kaskade.widgets import (
     KaskadeOptionList,
     KaskadeScrollableContainer,
     StretchyDataTable,
+    TableFrame,
 )
 from tests import configure_admin_service
 
@@ -187,6 +188,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
             async with app.run_test(size=(70, 18)) as pilot:
                 await pilot.pause()
                 table = app.query_one("#topics-table", DataTable)
+                frame = app.query_one("#topics-frame", TableFrame)
                 header = app.query_one(KaskadeHeader)
                 product = header.query_one("#kaskade-product", Static)
                 kafka = header.query_one("#kaskade-kafka", Static)
@@ -221,16 +223,18 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                     0,
                     table.get_component_styles("datatable--header").background_tint.a,
                 )
-                self.assertNotEqual("", table.styles.border_top[0])
-                self.assertGreater(table.styles.border_top[1].a, 0)
+                self.assertEqual("", table.styles.border_top[0])
+                self.assertNotEqual("", frame.styles.border_top[0])
+                self.assertGreater(frame.styles.border_top[1].a, 0)
                 footer = app.query_one(Footer)
                 self.assertIsInstance(footer, Footer)
-                for widget in (header, table, footer):
+                for widget in (header, frame, footer):
                     self.assertEqual(1, widget.region.x)
                     self.assertEqual(app.screen.region.right - 1, widget.region.right)
                 self.assertEqual(0, header.region.y)
                 self.assertEqual(1, header.content_region.y)
-                self.assertEqual(header.region.bottom, table.region.y)
+                self.assertEqual(header.region.bottom, frame.region.y)
+                self.assertEqual(frame.content_region, table.region)
                 self.assertIs(table, app.screen.focused)
                 self.assertTrue(
                     {"Describe", "Filter", "Refresh", "Create", "Quit", "Commands"}
@@ -484,7 +488,10 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 )
                 self.assertIsInstance(table, StretchyDataTable)
                 self.assertFalse(table.show_horizontal_scrollbar)
-                self.assertIn("Topics", table.border_title)
+                self.assertIn(
+                    "Topics",
+                    app.query_one("#topics-frame", TableFrame).border_title,
+                )
                 self.assertTrue(
                     {
                         "Theme",


### PR DESCRIPTION
## Summary

- keep main-table borders, titles, and subtitles on a persistent shared frame
- render Textual loading indicators inside the frame for admin and consumer tables
- add loading-state and layout coverage for both applications

## Testing

- `uv run --locked python -m scripts.analyze`
- `uv run --locked python -m scripts.tests`
- repository commit hooks, including E2E tests