### PR TITLE
feat(consumer): restructure record json

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -92,6 +92,10 @@ requiring newer functionality.
   deserializer for subsequent records, and preserve the diagnostics in details,
   cell tooltips, copy, and export. Broker failures and unexpected exceptions
   remain fatal.
+- Keep consumed-record JSON consistent across details, copy, and export. Represent
+  headers as ordered `key`/`value` objects, nest `type`, nullable Registry `schema`,
+  and optional fallback `error` under `deserializer`, and keep Registry metadata
+  resolution best-effort and cached per schema, topic, and field.
 
 ## TUI Interaction Conventions
 
@@ -244,6 +248,8 @@ from tests. Its `errors` topic cycles through valid and deliberately malformed
 Schema Registry key/value payloads for consumer fallback testing. Keep one
 Compose topology: three Confluent Kafka brokers, Apicurio Registry, and
 Confluent Schema Registry, with no web UI.
+Keep the sandbox topic registry lambda-free and route every topic through a
+named `Populator.populate_*` entrypoint.
 
 Reusable script classes and functions belong in `scripts/__init__.py`; keep
 individual script modules focused on executable workflows.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -306,7 +306,8 @@ Start with raw bytes:
 uv run kaskade consumer -b localhost:19092 --earliest -t string
 ```
 
-Test null keys and values:
+Test null keys and values. Every record in the `null` topic has both fields set
+to Kafka null:
 
 ```bash
 uv run kaskade consumer -b localhost:19092 --earliest -k string -v string -t null

--- a/USAGE.md
+++ b/USAGE.md
@@ -189,8 +189,70 @@ Select a record in consumer mode or open its details, then press `Ctrl+E` to exp
 JSON. Kaskade saves the file to the same destination as the Screenshot command: the
 Downloads directory in a local terminal or a browser download when web-hosted. The export
 includes the topic, partition, offset, timestamp, headers, and the deserialized key and value with
-their deserializer names. Export Record is omitted from the Footer; find it in contextual
+their deserializer types. Export Record is omitted from the Footer; find it in contextual
 Help or Commands.
+
+Record details, clipboard copies, and exports share the same JSON structure. Primitive and
+plain JSON deserializers have no Registry schema metadata:
+
+```json
+{
+  "topic": "orders",
+  "partition": 0,
+  "offset": 42,
+  "timestamp": "2026-08-28T14:12:05.120Z",
+  "headers": [
+    {"key": "source", "value": "storefront"}
+  ],
+  "key": {
+    "content": "order-1048",
+    "deserializer": {"type": "STRING", "schema": null}
+  },
+  "value": {
+    "content": {"status": "paid"},
+    "deserializer": {"type": "JSON", "schema": null}
+  }
+}
+```
+
+Schema Registry metadata is independent for the key and value. Kaskade includes it when
+the schema ID resolves to an unambiguous subject and version:
+
+```json
+{
+  "key": {
+    "content": {"id": "order-1049"},
+    "deserializer": {
+      "type": "REGISTRY",
+      "schema": {
+        "id": 12,
+        "subject": "orders-key",
+        "version": 2,
+        "type": "AVRO"
+      }
+    }
+  },
+  "value": {
+    "content": {"status": "shipped"},
+    "deserializer": {
+      "type": "REGISTRY",
+      "schema": {
+        "id": 27,
+        "subject": "orders-value",
+        "version": 5,
+        "type": "JSON"
+      }
+    }
+  }
+}
+```
+
+Headers remain an ordered array of `key` and `value` objects because Kafka permits repeated
+header names. JSON timestamps use UTC ISO 8601 with millisecond precision, or `null` when
+Kafka supplies no timestamp. Tombstone keys and values use `content: null`. Local Avro,
+local Protobuf, and non-schema deserializers use `schema: null`.
+In the records table, absent keys and values appear as a colored `null`; hover the cell
+to distinguish an absent key from a tombstone value.
 
 ## Consumer behavior
 
@@ -219,9 +281,27 @@ cannot be combined.
 
 If a configured key or value deserializer cannot decode an individual record,
 Kaskade shows `⚠`, displays that field with its BYTES fallback, and keeps
-consuming. Record details, copy, and export include the requested deserializer,
-fallback, and error. Hover the warning cell to see the diagnostic in a tooltip.
-The other field remains decoded normally.
+consuming. The recovered content retains the current Python byte string, while
+the diagnostic is nested inside the requested deserializer:
+
+```json
+{
+  "content": "b'\\xff'",
+  "deserializer": {
+    "type": "REGISTRY",
+    "schema": null,
+    "error": {
+      "message": "Unexpected magic byte -1",
+      "fallback": "BYTES"
+    }
+  }
+}
+```
+
+Record details, copy, and export preserve this structure. Hover the warning cell
+to see the same diagnostic in a tooltip. The other field remains decoded normally.
+Registry subject/version lookup is best-effort and cached; missing or ambiguous
+metadata produces `schema: null` without turning successful content into a fallback.
 
 ## Connections and security
 

--- a/kaskade/colors.py
+++ b/kaskade/colors.py
@@ -1,3 +1,4 @@
 PRIMARY = "primary"
 SECONDARY = "secondary"
 WARNING = "warning"
+NULL = "json.null"

--- a/kaskade/consumer.py
+++ b/kaskade/consumer.py
@@ -11,7 +11,7 @@ from textual.coordinate import Coordinate
 from textual.widgets import DataTable, Footer, Input, OptionList, Static
 from textual.widgets.option_list import Option
 
-from kaskade.colors import PRIMARY
+from kaskade.colors import NULL, PRIMARY
 from kaskade.colors import WARNING as WARNING_STYLE
 from kaskade.commands import RecordFilters
 from kaskade.deserializers import (
@@ -481,9 +481,11 @@ class ListRecords(Container):
         self.consume_records()
 
     @staticmethod
-    def _content_cell(content: str, *, warning: bool) -> str | Text:
-        content = content.strip()
-        if warning:
+    def _content_cell(outcome: DeserializationOutcome) -> str | Text:
+        if outcome.content is None:
+            return Text("null", style=NULL)
+        content = str(outcome.content).strip()
+        if outcome.used_fallback:
             return Text(
                 f"{WARNING_INDICATOR} {content}",
                 style=WARNING_STYLE,
@@ -494,15 +496,9 @@ class ListRecords(Container):
     def _record_row(cls, record: Record) -> list[str | Text]:
         record.resolve_deserializations()
         return [
-            cls._content_cell(
-                record.key_str(),
-                warning=record.key_outcome().used_fallback,
-            ),
-            cls._content_cell(
-                record.value_str(),
-                warning=record.value_outcome().used_fallback,
-            ),
-            record.timestamp,
+            cls._content_cell(record.key_outcome()),
+            cls._content_cell(record.value_outcome()),
+            record.timestamp_str(),
             str(record.partition),
             str(record.offset),
             str(record.headers_count()),
@@ -525,8 +521,19 @@ class ListRecords(Container):
         tooltip.append(f"\nError: {outcome.error}")
         return tooltip
 
+    @staticmethod
+    def _null_tooltip(record: Record, field_name: str) -> Text:
+        tooltip = Text()
+        tooltip.append(f"Null {field_name.title()}", style=WARNING_STYLE)
+        tooltip.append(f"\nRecord: {record.topic}[{record.partition}][{record.offset}]")
+        if field_name == "key":
+            tooltip.append("\nThis Kafka record has no key")
+        else:
+            tooltip.append("\nThis Kafka record is a tombstone")
+        return tooltip
+
     @classmethod
-    def _add_warning_tooltips(
+    def _add_cell_tooltips(
         cls,
         table: RecordDataTable,
         row_index: int,
@@ -541,6 +548,11 @@ class ListRecords(Container):
                     Coordinate(row_index, column_index),
                     cls._warning_tooltip(record, field_name, outcome),
                 )
+            elif outcome.content is None:
+                table.set_cell_tooltip(
+                    Coordinate(row_index, column_index),
+                    cls._null_tooltip(record, field_name),
+                )
 
     @work(group="records-consume")
     async def consume_records(self) -> None:
@@ -553,7 +565,7 @@ class ListRecords(Container):
                 self.records[record_id] = record
                 row_index = len(table.rows)
                 table.add_row(*self._record_row(record), key=record_id)
-                self._add_warning_tooltips(table, row_index, record)
+                self._add_cell_tooltips(table, row_index, record)
             self._update_table_title()
         except CONSUMER_EXCEPTIONS as ex:
             notify_error(self.app, "Consumption Error", ex)

--- a/kaskade/consumer.py
+++ b/kaskade/consumer.py
@@ -484,7 +484,7 @@ class ListRecords(Container):
     def _content_cell(outcome: DeserializationOutcome) -> str | Text:
         if outcome.content is None:
             return Text("null", style=NULL)
-        content = str(outcome.content).strip()
+        content = outcome.content_str().strip()
         if outcome.used_fallback:
             return Text(
                 f"{WARNING_INDICATOR} {content}",

--- a/kaskade/deserializers.py
+++ b/kaskade/deserializers.py
@@ -1,7 +1,9 @@
 import json
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum, auto
+from struct import error as StructError
 from struct import unpack
 from typing import Any
 
@@ -26,7 +28,21 @@ from kaskade.utils import avro_to_py, file_to_bytes, unpack_bytes
 
 
 class DeserializationError(Exception):
-    """Raised when deserializer configuration or input framing is invalid."""
+    """Raised when configuration, framing, or payload data cannot be deserialized."""
+
+
+def _unpack_payload(struct_format: str, data: bytes) -> Any:
+    try:
+        return unpack_bytes(struct_format, data)
+    except StructError as ex:
+        raise DeserializationError(str(ex)) from ex
+
+
+def _deserialize_avro(deserialize: Callable[..., Any], *args: Any) -> Any:
+    try:
+        return deserialize(*args)
+    except IndexError as ex:
+        raise DeserializationError(str(ex)) from ex
 
 
 DESERIALIZATION_EXCEPTIONS: tuple[type[Exception], ...] = (
@@ -122,35 +138,35 @@ class BooleanDeserializer(Deserializer):
     def deserialize(
         self, data: bytes, topic: str | None = None, context: MessageField = MessageField.NONE
     ) -> Any:
-        return unpack_bytes(">?", data)
+        return _unpack_payload(">?", data)
 
 
 class FloatDeserializer(Deserializer):
     def deserialize(
         self, data: bytes, topic: str | None = None, context: MessageField = MessageField.NONE
     ) -> Any:
-        return unpack_bytes(">f", data)
+        return _unpack_payload(">f", data)
 
 
 class DoubleDeserializer(Deserializer):
     def deserialize(
         self, data: bytes, topic: str | None = None, context: MessageField = MessageField.NONE
     ) -> Any:
-        return unpack_bytes(">d", data)
+        return _unpack_payload(">d", data)
 
 
 class LongDeserializer(Deserializer):
     def deserialize(
         self, data: bytes, topic: str | None = None, context: MessageField = MessageField.NONE
     ) -> Any:
-        return unpack_bytes(">q", data)
+        return _unpack_payload(">q", data)
 
 
 class IntegerDeserializer(Deserializer):
     def deserialize(
         self, data: bytes, topic: str | None = None, context: MessageField = MessageField.NONE
     ) -> Any:
-        return unpack_bytes(">i", data)
+        return _unpack_payload(">i", data)
 
 
 class JsonDeserializer(Deserializer):
@@ -226,7 +242,11 @@ class RegistryDeserializer(Deserializer):
             case "JSON":
                 return self.json_deserializer(data, SerializationContext(topic, context))
             case "AVRO":
-                return self.avro_deserializer(data, SerializationContext(topic, context))
+                return _deserialize_avro(
+                    self.avro_deserializer,
+                    data,
+                    SerializationContext(topic, context),
+                )
             case _:
                 raise DeserializationError("Schema type not supported")
 
@@ -323,7 +343,7 @@ class AvroDeserializer(Deserializer):
             raise DeserializationError("Avro schema file not found")
 
         payload = self._payload(data)
-        return avro_to_py(schema_path, payload)
+        return _deserialize_avro(avro_to_py, schema_path, payload)
 
     def _payload(self, data: bytes) -> bytes:
         if self.framing == "raw":

--- a/kaskade/deserializers.py
+++ b/kaskade/deserializers.py
@@ -1,5 +1,6 @@
 import json
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from enum import Enum, auto
 from struct import unpack
 from typing import Any
@@ -19,6 +20,7 @@ from google.protobuf.json_format import MessageToDict
 from google.protobuf.message import DecodeError, Message
 from google.protobuf.message_factory import GetMessages
 
+from kaskade import logger
 from kaskade.configs import SCHEMA_REGISTRY_MAGIC_BYTE
 from kaskade.utils import avro_to_py, file_to_bytes, unpack_bytes
 
@@ -36,6 +38,7 @@ DESERIALIZATION_EXCEPTIONS: tuple[type[Exception], ...] = (
     SerializationError,
     DecodeError,
 )
+SCHEMA_METADATA_EXCEPTIONS = DESERIALIZATION_EXCEPTIONS + (AttributeError, TypeError)
 
 
 class Deserialization(Enum):
@@ -66,12 +69,39 @@ class Deserialization(Enum):
         return [str(name) for name in Deserialization]
 
 
+@dataclass(frozen=True)
+class RegistrySchema:
+    id: int
+    subject: str
+    version: int
+    type: str
+
+    def dict(self) -> dict[str, int | str]:
+        return {
+            "id": self.id,
+            "subject": self.subject,
+            "version": self.version,
+            "type": self.type,
+        }
+
+
+@dataclass(frozen=True)
+class DeserializationResult:
+    content: Any
+    schema: RegistrySchema | None = None
+
+
 class Deserializer(ABC):
     @abstractmethod
     def deserialize(
         self, data: bytes, topic: str | None = None, context: MessageField = MessageField.NONE
     ) -> Any:
         pass
+
+    def deserialize_with_metadata(
+        self, data: bytes, topic: str | None = None, context: MessageField = MessageField.NONE
+    ) -> DeserializationResult:
+        return DeserializationResult(self.deserialize(data, topic, context))
 
 
 class DefaultDeserializer(Deserializer):
@@ -137,10 +167,31 @@ class RegistryDeserializer(Deserializer):
         self.json_deserializer = ConfluentJsonDeserializer(
             None, schema_registry_client=self.registry_client
         )
+        self._schema_cache: dict[tuple[int, str, MessageField], RegistrySchema | None] = {}
 
     def deserialize(
         self, data: bytes, topic: str | None = None, context: MessageField = MessageField.NONE
     ) -> Any:
+        _, schema_type = self._schema(data, topic, context)
+        return self._deserialize_content(data, topic, context, schema_type)
+
+    def deserialize_with_metadata(
+        self, data: bytes, topic: str | None = None, context: MessageField = MessageField.NONE
+    ) -> DeserializationResult:
+        schema_id, schema_type = self._schema(data, topic, context)
+        content = self._deserialize_content(data, topic, context, schema_type)
+        assert topic is not None
+        return DeserializationResult(
+            content,
+            self._resolve_schema(schema_id, schema_type, topic, context),
+        )
+
+    def _schema(
+        self,
+        data: bytes,
+        topic: str | None,
+        context: MessageField,
+    ) -> tuple[int, str]:
         if topic is None:
             raise DeserializationError("Topic name needed")
 
@@ -159,14 +210,89 @@ class RegistryDeserializer(Deserializer):
             )
 
         schema = self.registry_client.get_schema(schema_id)
+        if schema.schema_type is None:
+            raise DeserializationError("Schema type not supported")
+        return schema_id, schema.schema_type.upper()
 
-        match schema.schema_type:
+    def _deserialize_content(
+        self,
+        data: bytes,
+        topic: str | None,
+        context: MessageField,
+        schema_type: str,
+    ) -> Any:
+        assert topic is not None
+        match schema_type:
             case "JSON":
                 return self.json_deserializer(data, SerializationContext(topic, context))
             case "AVRO":
                 return self.avro_deserializer(data, SerializationContext(topic, context))
             case _:
                 raise DeserializationError("Schema type not supported")
+
+    def _resolve_schema(
+        self,
+        schema_id: int,
+        schema_type: str,
+        topic: str,
+        context: MessageField,
+    ) -> RegistrySchema | None:
+        cache_key = (schema_id, topic, context)
+        if cache_key in self._schema_cache:
+            return self._schema_cache[cache_key]
+
+        try:
+            registrations = self.registry_client.get_schema_versions(schema_id)
+            result = self._select_schema(
+                schema_id,
+                schema_type,
+                topic,
+                context,
+                registrations,
+            )
+        except SCHEMA_METADATA_EXCEPTIONS as ex:
+            logger.warning(
+                "schema metadata lookup failed schema_id=%d topic=%s field=%s error=%s",
+                schema_id,
+                topic,
+                context.name,
+                ex,
+            )
+            result = None
+
+        self._schema_cache[cache_key] = result
+        return result
+
+    @staticmethod
+    def _select_schema(
+        schema_id: int,
+        schema_type: str,
+        topic: str,
+        context: MessageField,
+        registrations: list[Any],
+    ) -> RegistrySchema | None:
+        candidates = [
+            registration
+            for registration in registrations
+            if registration.subject is not None and registration.version is not None
+        ]
+        selected = candidates[0] if len(candidates) == 1 else None
+        if selected is None:
+            conventional_subject = f"{topic}-{context.name.lower()}"
+            conventional = [
+                registration
+                for registration in candidates
+                if registration.subject == conventional_subject
+            ]
+            selected = conventional[0] if len(conventional) == 1 else None
+        if selected is None:
+            return None
+        return RegistrySchema(
+            id=schema_id,
+            subject=selected.subject,
+            version=selected.version,
+            type=schema_type,
+        )
 
 
 class AvroDeserializer(Deserializer):

--- a/kaskade/models.py
+++ b/kaskade/models.py
@@ -289,6 +289,11 @@ class DeserializationOutcome:
             }
         return {"content": self.content, "deserializer": deserializer}
 
+    def content_str(self) -> str:
+        if isinstance(self.content, bool):
+            return str(self.content).lower()
+        return str(self.content)
+
 
 @dataclass(eq=False)
 class Record:
@@ -402,10 +407,10 @@ class Record:
         return self.value_outcome().content
 
     def key_str(self) -> str:
-        return str(self.key_deserialized())
+        return self.key_outcome().content_str()
 
     def value_str(self) -> str:
-        return str(self.value_deserialized())
+        return self.value_outcome().content_str()
 
     def timestamp_json(self) -> str | None:
         timestamp = self._timestamp_utc()

--- a/kaskade/models.py
+++ b/kaskade/models.py
@@ -1,10 +1,17 @@
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from enum import Enum, auto
 from typing import Any
 
 from confluent_kafka.serialization import MessageField
 
-from kaskade.deserializers import DESERIALIZATION_EXCEPTIONS, Deserialization, Deserializer
+from kaskade.deserializers import (
+    DESERIALIZATION_EXCEPTIONS,
+    Deserialization,
+    DeserializationResult,
+    Deserializer,
+    RegistrySchema,
+)
 
 _NOT_DESERIALIZED = object()
 
@@ -255,11 +262,15 @@ class Header:
     def value_str(self) -> str:
         return str(self.value_deserialized())
 
+    def dict(self) -> dict[str, Any]:
+        return {"key": self.key, "value": self.value_deserialized()}
+
 
 @dataclass(frozen=True)
 class DeserializationOutcome:
     requested: Deserialization
     content: Any
+    schema: RegistrySchema | None = None
     error: Exception | None = None
 
     @property
@@ -267,16 +278,16 @@ class DeserializationOutcome:
         return self.error is not None
 
     def dict(self) -> dict[str, Any]:
-        result: dict[str, Any] = {
-            "deserializer": self.requested.name,
-            "content": self.content,
+        deserializer: dict[str, Any] = {
+            "type": self.requested.name,
+            "schema": self.schema.dict() if self.schema is not None else None,
         }
         if self.error is not None:
-            result |= {
+            deserializer["error"] = {
+                "message": str(self.error),
                 "fallback": Deserialization.BYTES.name,
-                "error": str(self.error),
             }
-        return result
+        return {"content": self.content, "deserializer": deserializer}
 
 
 @dataclass(eq=False)
@@ -284,7 +295,7 @@ class Record:
     topic: str = ""
     partition: int = -1
     offset: int = -1
-    timestamp: str = ""
+    timestamp: datetime | None = None
     key: bytes | None = None
     value: bytes | None = None
     headers: list[Header] = field(default_factory=list)
@@ -322,8 +333,8 @@ class Record:
             "topic": self.topic,
             "partition": self.partition,
             "offset": self.offset,
-            "timestamp": self.timestamp,
-            "headers": [(header.key, header.value_deserialized()) for header in self.headers],
+            "timestamp": self.timestamp_json(),
+            "headers": [header.dict() for header in self.headers],
             "key": self.key_outcome().dict(),
             "value": self.value_outcome().dict(),
         }
@@ -362,12 +373,20 @@ class Record:
         if deserializer is None:
             return DeserializationOutcome(requested, str(raw))
         try:
-            return DeserializationOutcome(
-                requested,
-                deserializer.deserialize(raw, self.topic, field),
-            )
+            result = self._deserialize_result(deserializer, raw, field)
+            return DeserializationOutcome(requested, result.content, result.schema)
         except DESERIALIZATION_EXCEPTIONS as ex:
-            return DeserializationOutcome(requested, str(raw), ex)
+            return DeserializationOutcome(requested, str(raw), error=ex)
+
+    def _deserialize_result(
+        self,
+        deserializer: Deserializer,
+        raw: bytes,
+        field: MessageField,
+    ) -> DeserializationResult:
+        if isinstance(deserializer, Deserializer):
+            return deserializer.deserialize_with_metadata(raw, self.topic, field)
+        return DeserializationResult(deserializer.deserialize(raw, self.topic, field))
 
     def resolve_deserializations(self) -> None:
         self.key_outcome()
@@ -387,3 +406,23 @@ class Record:
 
     def value_str(self) -> str:
         return str(self.value_deserialized())
+
+    def timestamp_json(self) -> str | None:
+        timestamp = self._timestamp_utc()
+        if timestamp is None:
+            return None
+        return timestamp.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+    def timestamp_str(self) -> str:
+        timestamp = self._timestamp_utc()
+        if timestamp is None:
+            return ""
+        return timestamp.astimezone().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+
+    def _timestamp_utc(self) -> datetime | None:
+        timestamp = self.timestamp
+        if timestamp is None:
+            return None
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        return timestamp.astimezone(timezone.utc)

--- a/kaskade/services.py
+++ b/kaskade/services.py
@@ -300,15 +300,11 @@ class ConsumerService:
             )
 
     @staticmethod
-    def _message_timestamp(message: Any) -> str:
+    def _message_timestamp(message: Any) -> datetime | None:
         timestamp_available, timestamp = message.timestamp()
         if timestamp_available <= 0:
-            return ""
-        return (
-            datetime.fromtimestamp(timestamp / 1000, tz=timezone.utc)
-            .astimezone()
-            .strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
-        )
+            return None
+        return datetime.fromtimestamp(timestamp / 1000, tz=timezone.utc)
 
     @staticmethod
     def _matches(

--- a/sandbox/__main__.py
+++ b/sandbox/__main__.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from functools import partial
 from pathlib import Path
 from time import sleep
-from typing import Any
+from typing import Any, cast
 
 import click
 from confluent_kafka import KafkaError, KafkaException, Producer
@@ -32,6 +32,7 @@ SANDBOX_PATH = Path(__file__).resolve().parent
 JSON_USER_SCHEMA = str(SANDBOX_PATH / "json_model" / "user.schema.json")
 AVRO_USER_SCHEMA = str(SANDBOX_PATH / "avro_model" / "user.avsc")
 ERRORS_TOPIC = "errors"
+NULL_TOPIC = "null"
 AVAILABLE_TOPICS = (
     "string",
     "integer",
@@ -39,7 +40,7 @@ AVAILABLE_TOPICS = (
     "float",
     "double",
     "boolean",
-    "null",
+    NULL_TOPIC,
     "json",
     "json-schema",
     "protobuf",
@@ -52,6 +53,32 @@ ERROR_CASES = ("key", "value", "both", "valid")
 MALFORMED_KEY_CASES = frozenset({"key", "both"})
 MALFORMED_VALUE_CASES = frozenset({"value", "both"})
 MALFORMED_PAYLOAD_BYTES = 32
+FAKE_NUMBER_MIN = 500
+FAKE_NUMBER_MAX = 10000
+
+
+def model_to_dict(value: Any, _: SerializationContext) -> dict[str, Any]:
+    return cast(dict[str, Any], vars(value))
+
+
+def fake_user(model: Callable[..., Any], faker: Faker) -> Any:
+    return model(name=faker.name())
+
+
+def serialize_with_context(
+    value: Any,
+    serializer: Callable[[Any, SerializationContext], Any],
+    topic: str,
+) -> Any:
+    return serializer(value, SerializationContext(topic, MessageField.VALUE))
+
+
+def serialize_protobuf(value: ProtobufUser) -> bytes:
+    return value.SerializeToString()
+
+
+def serialize_avro(value: AvroUser) -> bytes:
+    return py_to_avro(AVRO_USER_SCHEMA, vars(value))
 
 
 class Populator:
@@ -106,12 +133,119 @@ class Populator:
         serializer: Callable[[Any], Any],
         total_messages: int,
     ) -> None:
-        for n in range(total_messages):
+        for _ in range(total_messages):
             value = generator()
             self.producer.produce(topic, value=serializer(value), key=f"{value}")
         self.producer.flush(5)
 
-    def populate_registry_errors(
+    def populate_string(self, faker: Faker, total_messages: int) -> None:
+        self.populate("string", faker.name, str.encode, total_messages)
+
+    def populate_integer(self, faker: Faker, total_messages: int) -> None:
+        self._populate_number("integer", faker.pyint, ">i", total_messages)
+
+    def populate_long(self, faker: Faker, total_messages: int) -> None:
+        self._populate_number("long", faker.pyint, ">q", total_messages)
+
+    def populate_float(self, faker: Faker, total_messages: int) -> None:
+        self._populate_number("float", faker.pyfloat, ">f", total_messages)
+
+    def populate_double(self, faker: Faker, total_messages: int) -> None:
+        self._populate_number("double", faker.pyfloat, ">d", total_messages)
+
+    def _populate_number(
+        self,
+        topic: str,
+        generator: Callable[..., Any],
+        struct_format: str,
+        total_messages: int,
+    ) -> None:
+        self.populate(
+            topic,
+            partial(generator, min_value=FAKE_NUMBER_MIN, max_value=FAKE_NUMBER_MAX),
+            partial(pack_bytes, struct_format),
+            total_messages,
+        )
+
+    def populate_boolean(self, faker: Faker, total_messages: int) -> None:
+        self.populate("boolean", faker.pybool, partial(pack_bytes, ">?"), total_messages)
+
+    def populate_null(self, total_messages: int) -> None:
+        for _ in range(total_messages):
+            self.producer.produce(NULL_TOPIC, key=None, value=None)
+        self.producer.flush(5)
+
+    def populate_json(self, faker: Faker, total_messages: int) -> None:
+        self.populate("json", faker.json, str.encode, total_messages)
+
+    def populate_json_schema(
+        self,
+        serializer: JSONSerializer,
+        faker: Faker,
+        total_messages: int,
+    ) -> None:
+        self._populate_schema(
+            "json-schema",
+            JsonUser,
+            serializer,
+            faker,
+            total_messages,
+        )
+
+    def populate_protobuf(self, faker: Faker, total_messages: int) -> None:
+        self.populate(
+            "protobuf",
+            partial(fake_user, ProtobufUser, faker),
+            serialize_protobuf,
+            total_messages,
+        )
+
+    def populate_protobuf_schema(
+        self,
+        serializer: ProtobufSerializer,
+        faker: Faker,
+        total_messages: int,
+    ) -> None:
+        self._populate_schema(
+            "protobuf-schema",
+            ProtobufUser,
+            serializer,
+            faker,
+            total_messages,
+        )
+
+    def populate_avro(self, faker: Faker, total_messages: int) -> None:
+        self.populate(
+            "avro",
+            partial(fake_user, AvroUser, faker),
+            serialize_avro,
+            total_messages,
+        )
+
+    def populate_avro_schema(
+        self,
+        serializer: AvroSerializer,
+        faker: Faker,
+        total_messages: int,
+    ) -> None:
+        self._populate_schema("avro-schema", AvroUser, serializer, faker, total_messages)
+
+    def _populate_schema(
+        self,
+        topic: str,
+        model: Callable[..., Any],
+        serializer: Callable[[Any, SerializationContext], Any],
+        faker: Faker,
+        total_messages: int,
+    ) -> None:
+        self.populate(
+            topic,
+            partial(fake_user, model, faker),
+            partial(serialize_with_context, serializer=serializer, topic=topic),
+            total_messages,
+        )
+
+    def populate_errors(
         self,
         serializer: JSONSerializer,
         faker: Faker,
@@ -232,12 +366,12 @@ def main(
     avro_serializer = AvroSerializer(
         registry_client,
         file_to_str(AVRO_USER_SCHEMA),
-        lambda value, ctx: vars(value),
+        model_to_dict,
     )
     json_serializer = JSONSerializer(
         file_to_str(JSON_USER_SCHEMA),
         registry_client,
-        lambda value, ctx: vars(value),
+        model_to_dict,
     )
     protobuf_serializer = ProtobufSerializer(
         ProtobufUser, registry_client, {"use.deprecated.format": False}
@@ -252,87 +386,36 @@ def main(
 
     def topic_population(
         topic: str,
-        generator: Callable[[], Any],
-        serializer: Callable[[Any], Any],
+        action: Callable[..., None],
+        *args: Any,
     ) -> tuple[str, Callable[[], None]]:
-        return topic, partial(populator.populate, topic, generator, serializer, messages)
+        return topic, partial(action, *args, messages)
 
     topics: list[tuple[str, Callable[[], None]]] = [
-        topic_population(
-            "string",
-            lambda: faker.name(),
-            lambda value: value.encode("utf-8"),
-        ),
-        topic_population(
-            "integer",
-            lambda: faker.pyint(min_value=500, max_value=10000),
-            lambda value: pack_bytes(">i", value),
-        ),
-        topic_population(
-            "long",
-            lambda: faker.pyint(min_value=500, max_value=10000),
-            lambda value: pack_bytes(">q", value),
-        ),
-        topic_population(
-            "float",
-            lambda: faker.pyfloat(min_value=500, max_value=10000),
-            lambda value: pack_bytes(">f", value),
-        ),
-        topic_population(
-            "double",
-            lambda: faker.pyfloat(min_value=500, max_value=10000),
-            lambda value: pack_bytes(">d", value),
-        ),
-        topic_population(
-            "boolean",
-            lambda: faker.pybool(),
-            lambda value: pack_bytes(">?", value),
-        ),
-        topic_population(
-            "null",
-            lambda: "not null" if faker.pybool() else None,
-            lambda value: value.encode("utf-8") if value else None,
-        ),
-        topic_population(
-            "json",
-            lambda: faker.json(),
-            lambda value: value.encode("utf-8"),
-        ),
-        topic_population(
-            "json-schema",
-            lambda: JsonUser(name=faker.name()),
-            lambda value: json_serializer(
-                value, SerializationContext("json-schema", MessageField.VALUE)
-            ),
-        ),
-        topic_population(
-            "protobuf",
-            lambda: ProtobufUser(name=faker.name()),
-            lambda value: value.SerializeToString(),
-        ),
+        topic_population("string", populator.populate_string, faker),
+        topic_population("integer", populator.populate_integer, faker),
+        topic_population("long", populator.populate_long, faker),
+        topic_population("float", populator.populate_float, faker),
+        topic_population("double", populator.populate_double, faker),
+        topic_population("boolean", populator.populate_boolean, faker),
+        topic_population(NULL_TOPIC, populator.populate_null),
+        topic_population("json", populator.populate_json, faker),
+        topic_population("json-schema", populator.populate_json_schema, json_serializer, faker),
+        topic_population("protobuf", populator.populate_protobuf, faker),
         topic_population(
             "protobuf-schema",
-            lambda: ProtobufUser(name=faker.name()),
-            lambda value: protobuf_serializer(
-                value, SerializationContext("protobuf-schema", MessageField.VALUE)
-            ),
+            populator.populate_protobuf_schema,
+            protobuf_serializer,
+            faker,
         ),
-        topic_population(
-            "avro",
-            lambda: AvroUser(name=faker.name()),
-            lambda value: py_to_avro(AVRO_USER_SCHEMA, vars(value)),
-        ),
+        topic_population("avro", populator.populate_avro, faker),
         topic_population(
             "avro-schema",
-            lambda: AvroUser(name=faker.name()),
-            lambda value: avro_serializer(
-                value, SerializationContext("avro-schema", MessageField.VALUE)
-            ),
+            populator.populate_avro_schema,
+            avro_serializer,
+            faker,
         ),
-        (
-            ERRORS_TOPIC,
-            partial(populator.populate_registry_errors, json_serializer, faker, messages),
-        ),
+        topic_population(ERRORS_TOPIC, populator.populate_errors, json_serializer, faker),
     ]
     if selected_topics is not None:
         actions_by_topic = dict(topics)

--- a/scripts/screenshots.py
+++ b/scripts/screenshots.py
@@ -133,7 +133,15 @@ def mock_records() -> list[Record]:
             topic="order-events",
             partition=index % 3,
             offset=8_421 + index,
-            timestamp=f"2026-08-28 14:{12 + index:02d}:05.120",
+            timestamp=datetime(
+                2026,
+                8,
+                28,
+                14,
+                12 + index,
+                5,
+                120_000,
+            ).astimezone(),
             key=key.encode(),
             value=value.encode(),
             headers=[

--- a/tests/unit/tests_consumer.py
+++ b/tests/unit/tests_consumer.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import struct
 import unittest
 from datetime import datetime, timezone
 from io import StringIO
@@ -24,6 +25,7 @@ from kaskade.consumer import (
     record_json_renderable,
 )
 from kaskade.deserializers import (
+    BooleanDeserializer,
     Deserialization,
     DeserializationError,
     DeserializationResult,
@@ -617,6 +619,36 @@ class TestConsumptionCoordination(unittest.IsolatedAsyncioTestCase):
             finally:
                 release.set()
             await app.workers.wait_for_complete()
+
+    @patch("kaskade.consumer.ConsumerService")
+    async def test_boolean_cells_use_json_literals(self, consumer_service: MagicMock) -> None:
+        deserializer = BooleanDeserializer()
+        record = Record(
+            topic="boolean",
+            key=struct.pack(">?", False),
+            value=struct.pack(">?", True),
+            key_deserialization=Deserialization.BOOLEAN,
+            value_deserialization=Deserialization.BOOLEAN,
+            key_deserializer=deserializer,
+            value_deserializer=deserializer,
+        )
+        consumer_service.return_value.consume = AsyncMock(return_value=[record])
+        app = KaskadeConsumer(
+            "boolean",
+            {},
+            {},
+            {},
+            {},
+            Deserialization.BOOLEAN,
+            Deserialization.BOOLEAN,
+        )
+
+        async with app.run_test() as pilot:
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            row = app.query_one(RecordDataTable).get_row_at(0)
+
+            self.assertEqual(["false", "true"], row[:2])
 
     @patch("kaskade.consumer.ConsumerService")
     async def test_warning_record_has_visible_indicator_and_warning_cells(

--- a/tests/unit/tests_consumer.py
+++ b/tests/unit/tests_consumer.py
@@ -6,11 +6,13 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from confluent_kafka.serialization import MessageField
 from rich.text import Text
 from textual import events
 from textual.coordinate import Coordinate
 from textual.widgets import DataTable
 
+from kaskade.colors import NULL as NULL_STYLE
 from kaskade.colors import WARNING as WARNING_STYLE
 from kaskade.consumer import (
     KaskadeConsumer,
@@ -21,7 +23,14 @@ from kaskade.consumer import (
     record_json,
     record_json_renderable,
 )
-from kaskade.deserializers import Deserialization, DeserializationError, StringDeserializer
+from kaskade.deserializers import (
+    Deserialization,
+    DeserializationError,
+    DeserializationResult,
+    Deserializer,
+    RegistrySchema,
+    StringDeserializer,
+)
 from kaskade.help import HelpScreen
 from kaskade.models import Header, Record
 from kaskade.record_export import record_filename
@@ -42,7 +51,7 @@ def exported_record() -> Record:
         topic="orders",
         partition=2,
         offset=42,
-        timestamp="2026-08-28 14:12:05.120",
+        timestamp=datetime(2026, 8, 28, 14, 12, 5, 120_000, tzinfo=timezone.utc),
         headers=[
             Header("source", b"storefront", string_deserializer),
             Header("source", b"mobile", string_deserializer),
@@ -65,16 +74,22 @@ class TestRecordExport(unittest.TestCase):
                 "topic": "orders",
                 "partition": 2,
                 "offset": 42,
-                "timestamp": "2026-08-28 14:12:05.120",
-                "headers": [("source", "storefront"), ("source", "mobile")],
-                "key": {"deserializer": "STRING", "content": "order-1048"},
+                "timestamp": "2026-08-28T14:12:05.120Z",
+                "headers": [
+                    {"key": "source", "value": "storefront"},
+                    {"key": "source", "value": "mobile"},
+                ],
+                "key": {
+                    "content": "order-1048",
+                    "deserializer": {"type": "STRING", "schema": None},
+                },
                 "value": {
-                    "deserializer": "JSON",
                     "content": {
                         "status": "paid",
                         "customer": "Zoë",
                         "binary": b"\xff",
                     },
+                    "deserializer": {"type": "JSON", "schema": None},
                 },
             },
             record.dict(),
@@ -95,7 +110,8 @@ class TestRecordExport(unittest.TestCase):
 
         self.assertEqual(record_json(exported_record()).rstrip("\n"), renderable.text.plain)
         self.assertIn(
-            '  "key": {\n    "deserializer": "STRING",\n    "content": "order-1048"\n  }',
+            '  "key": {\n    "content": "order-1048",\n    "deserializer": {\n'
+            '      "type": "STRING",\n      "schema": null\n    }\n  }',
             renderable.text.plain,
         )
         self.assertFalse(renderable.text.no_wrap)
@@ -111,8 +127,59 @@ class TestRecordExport(unittest.TestCase):
         ).dict()
 
         self.assertEqual([], data["headers"])
+        self.assertIsNone(data["timestamp"])
         self.assertIsNone(data["key"]["content"])
         self.assertIsNone(data["value"]["content"])
+        self.assertEqual(
+            {"type": "STRING", "schema": None},
+            data["key"]["deserializer"],
+        )
+
+    def test_record_dict_preserves_tombstones_and_repeated_headers(self) -> None:
+        string_deserializer = StringDeserializer()
+        record = Record(
+            topic="orders",
+            partition=2,
+            offset=44,
+            headers=[
+                Header("trace-id", b"first", string_deserializer),
+                Header("trace-id", b"second", string_deserializer),
+            ],
+            key_deserialization=Deserialization.STRING,
+            value_deserialization=Deserialization.JSON,
+        )
+
+        self.assertEqual(
+            {
+                "topic": "orders",
+                "partition": 2,
+                "offset": 44,
+                "timestamp": None,
+                "headers": [
+                    {"key": "trace-id", "value": "first"},
+                    {"key": "trace-id", "value": "second"},
+                ],
+                "key": {
+                    "content": None,
+                    "deserializer": {"type": "STRING", "schema": None},
+                },
+                "value": {
+                    "content": None,
+                    "deserializer": {"type": "JSON", "schema": None},
+                },
+            },
+            record.dict(),
+        )
+
+    def test_record_dict_uses_the_requested_deserializer_type(self) -> None:
+        for deserialization in Deserialization:
+            with self.subTest(deserialization=deserialization):
+                data = Record(key_deserialization=deserialization).dict()
+
+                self.assertEqual(
+                    deserialization.name,
+                    data["key"]["deserializer"]["type"],
+                )
 
     def test_record_dict_preserves_deserialization_warning_metadata(self) -> None:
         key_deserializer = MagicMock()
@@ -121,6 +188,7 @@ class TestRecordExport(unittest.TestCase):
             topic="orders",
             partition=1,
             offset=10,
+            timestamp=datetime(2026, 8, 28, 14, 12, 7, 120_000, tzinfo=timezone.utc),
             key=b"\xff",
             value=b"paid",
             key_deserialization=Deserialization.JSON,
@@ -133,19 +201,109 @@ class TestRecordExport(unittest.TestCase):
 
         self.assertEqual(
             {
-                "deserializer": "JSON",
-                "fallback": "BYTES",
-                "content": "b'\\xff'",
-                "error": "malformed key",
+                "topic": "orders",
+                "partition": 1,
+                "offset": 10,
+                "timestamp": "2026-08-28T14:12:07.120Z",
+                "headers": [],
+                "key": {
+                    "content": "b'\\xff'",
+                    "deserializer": {
+                        "type": "JSON",
+                        "schema": None,
+                        "error": {
+                            "message": "malformed key",
+                            "fallback": "BYTES",
+                        },
+                    },
+                },
+                "value": {
+                    "content": "paid",
+                    "deserializer": {"type": "STRING", "schema": None},
+                },
             },
-            data["key"],
-        )
-        self.assertEqual(
-            {"deserializer": "STRING", "content": "paid"},
-            data["value"],
+            data,
         )
         self.assertTrue(record.has_deserialization_errors())
         key_deserializer.deserialize.assert_called_once()
+
+    def test_record_dict_keeps_key_and_value_schema_metadata_independent(self) -> None:
+        class MetadataDeserializer(Deserializer):
+            def __init__(self, content: object, schema: RegistrySchema):
+                self.content = content
+                self.schema = schema
+
+            def deserialize(
+                self,
+                data: bytes,
+                topic: str | None = None,
+                context: MessageField = MessageField.NONE,
+            ) -> object:
+                return self.content
+
+            def deserialize_with_metadata(
+                self,
+                data: bytes,
+                topic: str | None = None,
+                context: MessageField = MessageField.NONE,
+            ) -> DeserializationResult:
+                return DeserializationResult(self.content, self.schema)
+
+        record = Record(
+            topic="orders",
+            partition=0,
+            offset=43,
+            timestamp=datetime(2026, 8, 28, 14, 12, 6, 120_000, tzinfo=timezone.utc),
+            key=b"key",
+            value=b"value",
+            key_deserialization=Deserialization.REGISTRY,
+            value_deserialization=Deserialization.REGISTRY,
+            key_deserializer=MetadataDeserializer(
+                {"id": "order-1049"},
+                RegistrySchema(12, "orders-key", 2, "AVRO"),
+            ),
+            value_deserializer=MetadataDeserializer(
+                {"status": "shipped"},
+                RegistrySchema(27, "orders-value", 5, "JSON"),
+            ),
+        )
+
+        data = record.dict()
+
+        self.assertEqual(
+            {
+                "topic": "orders",
+                "partition": 0,
+                "offset": 43,
+                "timestamp": "2026-08-28T14:12:06.120Z",
+                "headers": [],
+                "key": {
+                    "content": {"id": "order-1049"},
+                    "deserializer": {
+                        "type": "REGISTRY",
+                        "schema": {
+                            "id": 12,
+                            "subject": "orders-key",
+                            "version": 2,
+                            "type": "AVRO",
+                        },
+                    },
+                },
+                "value": {
+                    "content": {"status": "shipped"},
+                    "deserializer": {
+                        "type": "REGISTRY",
+                        "schema": {
+                            "id": 27,
+                            "subject": "orders-value",
+                            "version": 5,
+                            "type": "JSON",
+                        },
+                    },
+                },
+            },
+            data,
+        )
 
     def test_record_filename_contains_identity_and_sanitized_export_time(self) -> None:
         record = Record(topic="orders.v1:archive", partition=2, offset=42)
@@ -516,6 +674,55 @@ class TestConsumptionCoordination(unittest.IsolatedAsyncioTestCase):
             await pilot.pause()
 
             self.assertIsNone(table.tooltip)
+
+    @patch("kaskade.consumer.ConsumerService")
+    async def test_null_key_and_value_have_colored_cells_and_tooltips(
+        self, consumer_service: MagicMock
+    ) -> None:
+        record = Record(
+            topic="orders",
+            partition=2,
+            offset=44,
+            key_deserialization=Deserialization.STRING,
+            value_deserialization=Deserialization.JSON,
+        )
+        consumer_service.return_value.consume = AsyncMock(return_value=[record])
+        app = KaskadeConsumer(
+            "orders",
+            {},
+            {},
+            {},
+            {},
+            Deserialization.STRING,
+            Deserialization.JSON,
+        )
+
+        async with app.run_test() as pilot:
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            table = app.query_one(RecordDataTable)
+            row = table.get_row_at(0)
+
+            for cell in row[:2]:
+                self.assertIsInstance(cell, Text)
+                self.assertEqual("null", cell.plain)
+                self.assertEqual(NULL_STYLE, cell.style)
+
+            table.hover_coordinate = Coordinate(0, 0)
+            await pilot.pause()
+
+            self.assertIsInstance(table.tooltip, Text)
+            self.assertIn("Null Key", table.tooltip.plain)
+            self.assertIn("This Kafka record has no key", table.tooltip.plain)
+            self.assertEqual(WARNING_STYLE, table.tooltip.spans[0].style)
+
+            table.hover_coordinate = Coordinate(0, 1)
+            await pilot.pause()
+
+            self.assertIsInstance(table.tooltip, Text)
+            self.assertIn("Null Value", table.tooltip.plain)
+            self.assertIn("This Kafka record is a tombstone", table.tooltip.plain)
+            self.assertEqual(WARNING_STYLE, table.tooltip.spans[0].style)
 
     @patch("kaskade.consumer.ConsumerService")
     async def test_duplicate_requests_do_not_schedule_overlapping_consumers(

--- a/tests/unit/tests_deserializers.py
+++ b/tests/unit/tests_deserializers.py
@@ -93,6 +93,20 @@ class TestDeserializer(unittest.TestCase):
         key_deserializer.deserialize.assert_called_once()
         value_deserializer.deserialize.assert_called_once()
 
+    def test_record_boolean_strings_use_json_literals(self):
+        deserializer = BooleanDeserializer()
+        record = Record(
+            key=struct.pack(">?", False),
+            value=struct.pack(">?", True),
+            key_deserializer=deserializer,
+            value_deserializer=deserializer,
+        )
+
+        self.assertEqual("false", record.key_str())
+        self.assertEqual("true", record.value_str())
+        self.assertIs(record.dict()["key"]["content"], False)
+        self.assertIs(record.dict()["value"]["content"], True)
+
     def test_record_propagates_unexpected_deserialization_errors(self):
         for exception in (RuntimeError("unexpected"), IndexError("unexpected")):
             deserializer = MagicMock()

--- a/tests/unit/tests_deserializers.py
+++ b/tests/unit/tests_deserializers.py
@@ -67,6 +67,12 @@ class TestDeserializer(unittest.TestCase):
         self.assertEqual(str(value), header.value_deserialized())
         deserializer.deserialize.assert_called_once_with(value)
 
+    def test_header_falls_back_for_malformed_integer(self):
+        value = b"586"
+        header = Header(value=value, value_deserializer=IntegerDeserializer())
+
+        self.assertEqual(str(value), header.value_deserialized())
+
     def test_record_caches_successful_deserialization(self):
         key_deserializer = MagicMock()
         key_deserializer.deserialize.return_value = "customer-1"
@@ -88,12 +94,39 @@ class TestDeserializer(unittest.TestCase):
         value_deserializer.deserialize.assert_called_once()
 
     def test_record_propagates_unexpected_deserialization_errors(self):
-        deserializer = MagicMock()
-        deserializer.deserialize.side_effect = RuntimeError("unexpected")
-        record = Record(key=b"payload", key_deserializer=deserializer)
+        for exception in (RuntimeError("unexpected"), IndexError("unexpected")):
+            deserializer = MagicMock()
+            deserializer.deserialize.side_effect = exception
+            record = Record(key=b"payload", key_deserializer=deserializer)
 
-        with self.assertRaisesRegex(RuntimeError, "unexpected"):
-            record.key_str()
+            with (
+                self.subTest(exception=type(exception).__name__),
+                self.assertRaisesRegex(type(exception), "unexpected"),
+            ):
+                record.key_str()
+
+    def test_record_falls_back_for_malformed_integer(self):
+        record = Record(
+            topic="integer",
+            key=b"586",
+            key_deserialization=Deserialization.INTEGER,
+            key_deserializer=IntegerDeserializer(),
+        )
+
+        self.assertEqual(
+            {
+                "content": "b'586'",
+                "deserializer": {
+                    "type": "INTEGER",
+                    "schema": None,
+                    "error": {
+                        "message": "unpack requires a buffer of 4 bytes",
+                        "fallback": "BYTES",
+                    },
+                },
+            },
+            record.dict()["key"],
+        )
 
     def test_header_propagates_unexpected_errors(self):
         deserializer = MagicMock()
@@ -118,6 +151,24 @@ class TestDeserializer(unittest.TestCase):
         result = deserializer.deserialize(struct.pack(">i", expected_value))
 
         self.assertEqual(expected_value, result)
+
+    def test_fixed_width_deserializers_normalize_invalid_payload_size(self):
+        deserializers = (
+            BooleanDeserializer(),
+            IntegerDeserializer(),
+            LongDeserializer(),
+            FloatDeserializer(),
+            DoubleDeserializer(),
+        )
+
+        for deserializer in deserializers:
+            with (
+                self.subTest(deserializer=type(deserializer).__name__),
+                self.assertRaisesRegex(DeserializationError, "unpack requires") as raised,
+            ):
+                deserializer.deserialize(b"586")
+
+            self.assertIsInstance(raised.exception.__cause__, struct.error)
 
     def test_default_deserialization(self):
         expected_value = os.urandom(10)
@@ -192,6 +243,22 @@ class TestDeserializer(unittest.TestCase):
         result = deserializer.deserialize(b"\x00\x00\x00\x00\x00" + encoded, "", MessageField.VALUE)
 
         self.assertEqual(expected_value, result)
+
+    @patch("kaskade.deserializers.SchemaRegistryClient")
+    def test_registry_avro_normalizes_corrupt_payload_error(self, mock_sr_client_class):
+        schema = mock_sr_client_class.return_value.get_schema.return_value
+        schema.schema_str = file_to_str(AVRO_PATH)
+        schema.schema_type = "AVRO"
+        deserializer = RegistryDeserializer({})
+
+        with self.assertRaises(DeserializationError) as raised:
+            deserializer.deserialize(
+                b"\x00\x00\x00\x00\x00\xff",
+                "orders",
+                MessageField.VALUE,
+            )
+
+        self.assertIsInstance(raised.exception.__cause__, IndexError)
 
     @patch("kaskade.deserializers.SchemaRegistryClient")
     def test_registry_deserialization_json(self, mock_sr_client_class):
@@ -325,6 +392,14 @@ class TestDeserializer(unittest.TestCase):
 
         result = deserializer.deserialize(encoded, "", MessageField.VALUE)
         self.assertEqual(expected_value, result)
+
+    def test_avro_normalizes_corrupt_payload_error(self):
+        deserializer = AvroDeserializer({"value": AVRO_PATH})
+
+        with self.assertRaises(DeserializationError) as raised:
+            deserializer.deserialize(b"\xff", "orders", MessageField.VALUE)
+
+        self.assertIsInstance(raised.exception.__cause__, IndexError)
 
     def test_avro_deserialization_with_magic_byte(self):
         expected_value = {"name": "Pedro Pascal"}

--- a/tests/unit/tests_deserializers.py
+++ b/tests/unit/tests_deserializers.py
@@ -4,6 +4,7 @@ import struct
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from confluent_kafka.serialization import MessageField
@@ -207,6 +208,95 @@ class TestDeserializer(unittest.TestCase):
         )
 
         self.assertEqual(expected_value, result)
+
+    @patch("kaskade.deserializers.SchemaRegistryClient")
+    def test_registry_metadata_uses_a_unique_registration_and_caches_it(self, mock_sr_client_class):
+        registry_client = mock_sr_client_class.return_value
+        registry_client.get_schema.return_value.schema_type = "JSON"
+        registry_client.get_schema_versions.return_value = [
+            SimpleNamespace(subject="orders-key", version=2)
+        ]
+        deserializer = RegistryDeserializer({})
+        deserializer.json_deserializer = MagicMock(return_value={"id": "order-1049"})
+        payload = b"\x00\x00\x00\x00\x0c{}"
+
+        first = deserializer.deserialize_with_metadata(payload, "orders", MessageField.KEY)
+        second = deserializer.deserialize_with_metadata(payload, "orders", MessageField.KEY)
+
+        self.assertEqual({"id": "order-1049"}, first.content)
+        self.assertEqual(first, second)
+        self.assertIsNotNone(first.schema)
+        self.assertEqual(
+            {
+                "id": 12,
+                "subject": "orders-key",
+                "version": 2,
+                "type": "JSON",
+            },
+            first.schema.dict(),
+        )
+        registry_client.get_schema_versions.assert_called_once_with(12)
+
+    @patch("kaskade.deserializers.SchemaRegistryClient")
+    def test_registry_metadata_prefers_the_conventional_field_subject(self, mock_sr_client_class):
+        registry_client = mock_sr_client_class.return_value
+        registry_client.get_schema.return_value.schema_type = "AVRO"
+        registry_client.get_schema_versions.return_value = [
+            SimpleNamespace(subject="shared-order", version=1),
+            SimpleNamespace(subject="orders-value", version=5),
+        ]
+        deserializer = RegistryDeserializer({})
+        deserializer.avro_deserializer = MagicMock(return_value={"status": "shipped"})
+
+        result = deserializer.deserialize_with_metadata(
+            b"\x00\x00\x00\x00\x1bpayload",
+            "orders",
+            MessageField.VALUE,
+        )
+
+        self.assertIsNotNone(result.schema)
+        self.assertEqual("orders-value", result.schema.subject)
+        self.assertEqual(5, result.schema.version)
+
+    @patch("kaskade.deserializers.SchemaRegistryClient")
+    def test_registry_metadata_is_null_when_registrations_are_ambiguous(self, mock_sr_client_class):
+        registry_client = mock_sr_client_class.return_value
+        registry_client.get_schema.return_value.schema_type = "JSON"
+        registry_client.get_schema_versions.return_value = [
+            SimpleNamespace(subject="shared-one", version=1),
+            SimpleNamespace(subject="shared-two", version=2),
+        ]
+        deserializer = RegistryDeserializer({})
+        deserializer.json_deserializer = MagicMock(return_value={"status": "paid"})
+
+        result = deserializer.deserialize_with_metadata(
+            b"\x00\x00\x00\x00\x1b{}",
+            "orders",
+            MessageField.VALUE,
+        )
+
+        self.assertEqual({"status": "paid"}, result.content)
+        self.assertIsNone(result.schema)
+
+    @patch("kaskade.deserializers.SchemaRegistryClient")
+    def test_registry_metadata_lookup_failure_does_not_fail_deserialization(
+        self, mock_sr_client_class
+    ):
+        registry_client = mock_sr_client_class.return_value
+        registry_client.get_schema.return_value.schema_type = "JSON"
+        registry_client.get_schema_versions.side_effect = OSError("registry unavailable")
+        deserializer = RegistryDeserializer({})
+        deserializer.json_deserializer = MagicMock(return_value={"status": "paid"})
+
+        with self.assertLogs("kaskade", level="WARNING"):
+            result = deserializer.deserialize_with_metadata(
+                b"\x00\x00\x00\x00\x1b{}",
+                "orders",
+                MessageField.VALUE,
+            )
+
+        self.assertEqual({"status": "paid"}, result.content)
+        self.assertIsNone(result.schema)
 
     def test_protobuf_deserialization(self):
         deserializer = ProtobufDeserializer({"descriptor": DESCRIPTOR_PATH, "value": "User"})

--- a/tests/unit/tests_sandbox.py
+++ b/tests/unit/tests_sandbox.py
@@ -1,5 +1,6 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from functools import partial
+from unittest.mock import MagicMock, call, patch
 
 import click
 from click.testing import CliRunner
@@ -13,10 +14,32 @@ from kaskade.authentication import (
     AwsMskOAuthCallback,
 )
 from kaskade.configs import BOOTSTRAP_SERVERS
-from sandbox.__main__ import AVAILABLE_TOPICS, ERRORS_TOPIC, Populator, main, sandbox_kafka_config
+from sandbox.__main__ import (
+    AVAILABLE_TOPICS,
+    ERRORS_TOPIC,
+    NULL_TOPIC,
+    Populator,
+    main,
+    sandbox_kafka_config,
+)
 
 
 class TestPopulator(unittest.TestCase):
+    @patch("sandbox.__main__.Producer")
+    @patch("sandbox.__main__.AdminClient")
+    def test_null_topic_contains_only_null_keys_and_values(
+        self, _: MagicMock, mock_producer: MagicMock
+    ) -> None:
+        populator = Populator({})
+
+        populator.populate_null(3)
+
+        self.assertEqual(
+            [call(NULL_TOPIC, key=None, value=None)] * 3,
+            mock_producer.return_value.produce.call_args_list,
+        )
+        mock_producer.return_value.flush.assert_called_once_with(5)
+
     @patch("sandbox.__main__.Producer")
     @patch("sandbox.__main__.AdminClient")
     def test_create_topic_uses_broker_replication_defaults(
@@ -131,6 +154,30 @@ class TestSandboxKafkaConfig(unittest.TestCase):
         )
         self.assertEqual(14, mock_run_population.call_count)
         self.assertEqual(ERRORS_TOPIC, mock_run_population.call_args.args[3])
+
+        actions = [
+            population_call.args[4] for population_call in mock_run_population.call_args_list
+        ]
+        self.assertTrue(all(isinstance(action, partial) for action in actions))
+        self.assertEqual(
+            [
+                mock_populator.return_value.populate_string,
+                mock_populator.return_value.populate_integer,
+                mock_populator.return_value.populate_long,
+                mock_populator.return_value.populate_float,
+                mock_populator.return_value.populate_double,
+                mock_populator.return_value.populate_boolean,
+                mock_populator.return_value.populate_null,
+                mock_populator.return_value.populate_json,
+                mock_populator.return_value.populate_json_schema,
+                mock_populator.return_value.populate_protobuf,
+                mock_populator.return_value.populate_protobuf_schema,
+                mock_populator.return_value.populate_avro,
+                mock_populator.return_value.populate_avro_schema,
+                mock_populator.return_value.populate_errors,
+            ],
+            [action.func for action in actions],
+        )
 
     @patch("sandbox.__main__.run_population")
     @patch("sandbox.__main__.Populator")

--- a/tests/unit/tests_services.py
+++ b/tests/unit/tests_services.py
@@ -379,7 +379,7 @@ class TestConsumerService(unittest.IsolatedAsyncioTestCase):
     async def test_consumes_records_in_batches(self, mock_class_consumer: MagicMock) -> None:
         message = MagicMock()
         message.error.return_value = None
-        message.timestamp.return_value = (0, 0)
+        message.timestamp.return_value = (1, 1000)
         message.partition.return_value = 0
         message.offset.return_value = 1
         message.key.return_value = b"key"
@@ -401,6 +401,7 @@ class TestConsumerService(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(1, len(records))
         self.assertEqual("key", records[0].key_str())
+        self.assertEqual("1970-01-01T00:00:01.000Z", records[0].dict()["timestamp"])
         consumer.consume.assert_called_once_with(1, timeout=service.timeout)
 
     @patch("kaskade.services.Consumer")
@@ -431,7 +432,10 @@ class TestConsumerService(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(records[1].key_outcome().used_fallback)
         self.assertFalse(records[1].value_outcome().used_fallback)
         self.assertFalse(records[2].has_deserialization_errors())
-        self.assertEqual("BYTES", records[1].dict()["key"]["fallback"])
+        self.assertEqual(
+            "BYTES",
+            records[1].dict()["key"]["deserializer"]["error"]["fallback"],
+        )
 
     @patch("kaskade.services.Consumer")
     async def test_filters_batches_until_a_record_matches(


### PR DESCRIPTION
## Summary

- nest deserializer type, schema metadata, and fallback errors in consumed-record JSON
- normalize exported headers and timestamps while improving null rendering and tooltips
- resolve per-field Schema Registry metadata with cached best-effort lookups
- standardize sandbox topic population with named entrypoints and deterministic null records

## Testing

- pre-commit hooks
- static analysis (Mypy, Black, Ruff, typos, actionlint)
- full unit test suite
- Docker-backed E2E test suite

Assisted-by: Codex GPT-5