### PR TITLE
fix(consumer): filter null record content consistently

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -11,6 +11,8 @@
 - Keep this file and affected user documentation concise and current. Record
   stable conventions, remove obsolete or contradicted guidance, and avoid
   implementation history.
+- Keep `USAGE.md` focused on end users. Document the development-only sandbox,
+  its population tool, and its access requirements in `DEVELOPMENT.md` only.
 - Importing `kaskade` must not create directories, open files, or modify the root
   logger. Configure the named logger lazily and tolerate an unavailable log
   destination.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -278,8 +278,50 @@ uv run python -m sandbox \
 ```
 
 The Schema Registry URL remains independently configurable with `--registry`.
-See the sandbox requirements under [IAM permissions](USAGE.md#iam-permissions)
-or [Kafka ACLs](USAGE.md#kafka-acls).
+
+The IAM principal used for population needs `Connect`, `CreateTopic`,
+`DescribeTopic`, and `WriteData`. Replace the placeholders and narrow the topic
+wildcard when appropriate:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ConnectToCluster",
+      "Effect": "Allow",
+      "Action": "kafka-cluster:Connect",
+      "Resource": "arn:aws:kafka:<region>:<account-id>:cluster/<cluster-name>/<cluster-uuid>"
+    },
+    {
+      "Sid": "CreateAndPopulateTopics",
+      "Effect": "Allow",
+      "Action": [
+        "kafka-cluster:CreateTopic",
+        "kafka-cluster:DescribeTopic",
+        "kafka-cluster:WriteData"
+      ],
+      "Resource": "arn:aws:kafka:<region>:<account-id>:topic/<cluster-name>/<cluster-uuid>/*"
+    }
+  ]
+}
+```
+
+For a SASL/SCRAM or mTLS cluster, grant the population principal access to the
+test topics. Run this as an ACL administrator and configure
+`admin-client.properties` for that administrator:
+
+```bash
+kafka-acls.sh \
+    --bootstrap-server "${BOOTSTRAP_SERVERS}" \
+    --command-config admin-client.properties \
+    --add \
+    --allow-principal "User:<principal>" \
+    --operation Create \
+    --operation Write \
+    --operation Describe \
+    --topic '*'
+```
 
 ### Run application smoke tests
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -255,7 +255,8 @@ as STRING without extra metadata. Timestamps are UTC ISO 8601 with milliseconds,
 or `null` when unavailable. Tombstones use `content: null`. Local and non-schema
 deserializers omit `schema`; Registry does too when resolution is ambiguous or
 unavailable. The records table renders absent keys and values as colored `null`
-with a distinguishing tooltip.
+with a distinguishing tooltip. Enter lowercase `null` in a key, value, or header
+filter to match null content.
 
 Byte content stays directly in `content`, and its BYTES deserializer carries the
 presentation encoding. Base64 is the default portable encoding:
@@ -479,7 +480,6 @@ The IAM principal used by `--aws` needs these `kafka-cluster` actions:
 | Admin (read only) | `Connect`, `DescribeTopic`, `DescribeTopicDynamicConfiguration`, `DescribeGroup` |
 | Admin (full access) | Read-only actions plus `CreateTopic`, `AlterTopic`, `DeleteTopic`, `AlterTopicDynamicConfiguration` |
 | Consumer | `Connect`, `DescribeTopic`, `ReadData`, `DescribeGroup`, `AlterGroup` |
-| Sandbox population | `Connect`, `CreateTopic`, `DescribeTopic`, `WriteData` |
 
 This policy enables all admin and consumer features. Replace the placeholders
 and narrow the topic wildcard when appropriate.
@@ -530,32 +530,6 @@ ephemeral groups named `kaskade-<uuid>`. For read-only admin access, remove
 and `ReadData` from the topic statement, then remove the
 `UseKaskadeConsumerGroups` statement.
 
-Use this policy for sandbox population:
-
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "ConnectToCluster",
-      "Effect": "Allow",
-      "Action": "kafka-cluster:Connect",
-      "Resource": "arn:aws:kafka:<region>:<account-id>:cluster/<cluster-name>/<cluster-uuid>"
-    },
-    {
-      "Sid": "CreateAndPopulateTopics",
-      "Effect": "Allow",
-      "Action": [
-        "kafka-cluster:CreateTopic",
-        "kafka-cluster:DescribeTopic",
-        "kafka-cluster:WriteData"
-      ],
-      "Resource": "arn:aws:kafka:<region>:<account-id>:topic/<cluster-name>/<cluster-uuid>/*"
-    }
-  ]
-}
-```
-
 See AWS's [authorization action semantics](https://docs.aws.amazon.com/msk/latest/developerguide/kafka-actions.html)
 and [common client policy use cases](https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control-use-cases.html)
 for dependencies and resource formats.
@@ -568,8 +542,7 @@ For SASL/SCRAM and mTLS connections, grant the Kafka principal these operations:
 | --- | --- | --- | --- |
 | Admin (read only) | `Describe`, `DescribeConfigs` | `Describe` on groups to display | `Describe` |
 | Admin (full access) | `Describe`, `DescribeConfigs`, `Create`, `Alter`, `Delete`, `AlterConfigs` | `Describe` on groups to display | `Describe` |
-| Consumer | `Read`, `Describe` on topics to consume | `Read`, `Describe` on the `kaskade-` prefix | None |
-| Sandbox population | `Create`, `Write`, `Describe` on topics to populate | None | None |
+| Consumer | `Read`, `Describe` on topics to consume | `Read`, `Describe` on the `kaskade-` prefix | — |
 
 Use `User:<username>` for SASL/SCRAM or the certificate principal for mTLS, such
 as `User:CN=kaskade`. Run the commands as an ACL administrator and configure
@@ -629,20 +602,6 @@ kafka-acls.sh \
     --operation Describe \
     --group kaskade- \
     --resource-pattern-type prefixed
-```
-
-Sandbox population access to all topics:
-
-```bash
-kafka-acls.sh \
-    --bootstrap-server "${BOOTSTRAP_SERVERS}" \
-    --command-config admin-client.properties \
-    --add \
-    --allow-principal "User:<principal>" \
-    --operation Create \
-    --operation Write \
-    --operation Describe \
-    --topic '*'
 ```
 
 Narrow `--topic '*'` with literal topic names or prefixed resource patterns when

--- a/kaskade/models.py
+++ b/kaskade/models.py
@@ -31,6 +31,8 @@ def bytes_data(data: bytes, bytes_encoding: BytesEncoding) -> str | list[int]:
 
 
 def content_str(content: Any, bytes_encoding: BytesEncoding) -> str:
+    if content is None:
+        return "null"
     if isinstance(content, bytes):
         return str(bytes_data(content, bytes_encoding))
     if isinstance(content, bool):

--- a/tests/unit/tests_deserializers.py
+++ b/tests/unit/tests_deserializers.py
@@ -100,6 +100,15 @@ class TestDeserializer(unittest.TestCase):
             Header("nullable", None, deserializer).dict(),
         )
 
+    def test_null_content_uses_json_literal_for_display(self):
+        record = Record()
+        header = Header("nullable", None)
+
+        self.assertEqual("null", record.key_str())
+        self.assertEqual("null", record.value_str())
+        self.assertEqual("null", header.value_str())
+        self.assertEqual("nullable:null", str(header))
+
     def test_record_caches_successful_deserialization(self):
         key_deserializer = MagicMock()
         key_deserializer.deserialize.return_value = "customer-1"

--- a/tests/unit/tests_services.py
+++ b/tests/unit/tests_services.py
@@ -26,7 +26,7 @@ from confluent_kafka.cimpl import CONSUMER_GROUP_STATE_STABLE, TopicPartition
 
 from kaskade.commands import CreateTopicCommand, RecordFilters
 from kaskade.deserializers import Deserialization, DeserializerPool, StringDeserializer
-from kaskade.models import MetricState, PartitionOffset, PartitionSelection
+from kaskade.models import Header, MetricState, PartitionOffset, PartitionSelection, Record
 from kaskade.services import ConsumerService, TopicService
 from tests import faker
 
@@ -299,6 +299,19 @@ class TestTopicService(unittest.IsolatedAsyncioTestCase):
 
 
 class TestConsumerService(unittest.IsolatedAsyncioTestCase):
+    def test_null_filters_use_json_literal_instead_of_python_literal(self) -> None:
+        record = Record(headers=[Header("nullable", None)])
+
+        filters = (
+            ("key", RecordFilters(key="null"), RecordFilters(key="None")),
+            ("value", RecordFilters(value="null"), RecordFilters(value="None")),
+            ("header", RecordFilters(header="null"), RecordFilters(header="None")),
+        )
+        for field, null_filter, none_filter in filters:
+            with self.subTest(field=field):
+                self.assertTrue(ConsumerService._matches(record, null_filter))
+                self.assertFalse(ConsumerService._matches(record, none_filter))
+
     @patch("kaskade.services.Consumer")
     async def test_assigns_only_explicit_partitions_at_selected_offsets(
         self, mock_class_consumer: MagicMock


### PR DESCRIPTION
## Summary

- render null record keys, values, and header values as null instead of None
- let key, value, and header text filters match null content with the lowercase null literal
- keep sandbox access instructions in the development guide and end-user guidance in USAGE.md

## Testing

- pre-commit hooks
- static analysis
- unit tests
- end-to-end tests

Assisted-by: Codex GPT-5