### PR TITLE
fix(ui): refine detail panels and focus navigation

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -105,6 +105,11 @@ The command-line value takes precedence and follows the same validation rules.
 
 Topic Details keeps partition, replica, in-sync replica, approximate record,
 consumer-group, member, and approximate lag totals visible above its tabs.
+The Partitions tab includes each partition's earliest and end offsets. Group
+Offsets shows committed and end offsets with lag for every group partition.
+End is the next offset after the partition's latest record; Committed is the
+group's saved next offset to consume. Lag is their non-negative difference.
+Only partitions with available committed offsets appear in Group Offsets.
 
 ### Keyboard shortcuts
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -189,9 +189,9 @@ approximately 20 MiB.
 
 Select a topic in Admin mode or a consumed record in Consumer mode, then press
 `y` to copy the topic name or readable record JSON. Record Details separates the
-key, value, ordered headers, and complete JSON into tabs while keeping the total
-raw payload size, partition, offset, and timestamp visible. The topic remains in
-the border title. In that modal, `y` copies the active tab's headers array, key
+key, value, ordered headers, and complete record JSON (Export) into tabs while
+keeping the total raw payload size, partition, offset, and timestamp visible.
+The topic remains in the border title. In that modal, `y` copies the active tab's headers array, key
 object, value object, or complete record object. Copy is also available in Topic
 Details, contextual Help, and Commands, but is omitted from the Footer.
 
@@ -242,7 +242,7 @@ Press `Ctrl+E` from the records table or any Record Details tab to export the
 complete record JSON. Local terminals save to Downloads; web-hosted sessions use
 a browser download. Export Record appears in Help and Commands, not the Footer.
 
-The complete JSON tab, records-table and JSON-tab copies, and exports share the
+The Export tab, records-table and Export-tab copies, and exported files share the
 contract in
 [`schemas/consumer-record.schema.json`](schemas/consumer-record.schema.json),
 which uses JSON Schema Draft 2020-12. Examples cover:

--- a/kaskade/admin.py
+++ b/kaskade/admin.py
@@ -293,6 +293,11 @@ class DescribeTopicScreen(HelpableModalScreen):
                 with TabPane(Content(f"Groups [{self.topic.groups_count()}]"), id="groups"):
                     yield self._groups_table()
                 with TabPane(
+                    Content(f"Group Offsets [{self.topic.group_partitions_count()}]"),
+                    id="group-offsets",
+                ):
+                    yield self._group_offsets_table()
+                with TabPane(
                     Content(f"Group Members [{self.topic.group_members_count()}]"),
                     id="group-members",
                 ):
@@ -334,22 +339,49 @@ class DescribeTopicScreen(HelpableModalScreen):
         table.cursor_type = "row"
         return table
 
+    def on_tabbed_content_tab_activated(self, event: TabbedContent.TabActivated) -> None:
+        table = event.pane.query_one(StretchyDataTable)
+        table.call_after_refresh(table._stretch_columns)
+
     def _partitions_table(self) -> StretchyDataTable[str]:
         table = self._new_table("partitions-table")
         table.add_column("ID", stretch=1)
         table.add_column("Leader", stretch=1)
+        table.add_column("Earliest", stretch=1)
+        table.add_column("End", stretch=1)
+        table.add_column("Records", stretch=1)
         table.add_column("ISRs", stretch=1)
         table.add_column("Replicas", stretch=1)
-        table.add_column("Records", stretch=1)
 
         for partition in self.topic.partitions:
             table.add_row(
                 str(partition.id),
                 str(partition.leader),
+                metric_value(self.topic.records_state, str(partition.low)),
+                metric_value(self.topic.records_state, str(partition.high)),
+                metric_value(self.topic.records_state, str(partition.records_count())),
                 str(partition.isrs),
                 str(partition.replicas),
-                str(partition.records_count()),
             )
+        return table
+
+    def _group_offsets_table(self) -> StretchyDataTable[str]:
+        table = self._new_table("group-offsets-table")
+        table.add_column("Group", width=18, stretch=3)
+        table.add_column("Partition", stretch=1)
+        table.add_column("Committed", stretch=1)
+        table.add_column("End", stretch=1)
+        table.add_column("Lag", stretch=1)
+
+        for group in self.topic.groups:
+            for partition in group.partitions:
+                table.add_row(
+                    group.id,
+                    str(partition.id),
+                    str(partition.offset),
+                    metric_value(self.topic.records_state, str(partition.high)),
+                    metric_value(self.topic.groups_state, str(partition.lag_count())),
+                )
         return table
 
     def _configurations_table(self) -> StretchyDataTable[str]:

--- a/kaskade/consumer.py
+++ b/kaskade/consumer.py
@@ -231,7 +231,7 @@ class ChunkSizeScreen(HelpableModalScreen[int]):
 
 
 class RecordFieldDetails(Container):
-    """Present one deserialized field with diagnostics and content."""
+    """Keep field diagnostics separate from independently scrollable content."""
 
     def __init__(
         self,
@@ -287,29 +287,30 @@ class RecordFieldDetails(Container):
         return error
 
     def compose(self) -> ComposeResult:
-        field_name = Static(classes="record-field-name")
-        field_name.display = self.field_name is not None
-        if self.field_name is not None:
-            field_name.update(labelled_value("Header", self.field_name))
-        yield field_name
+        with KaskadeScrollableContainer(classes="record-field-metadata", can_focus=False):
+            field_name = Static(classes="record-field-name")
+            field_name.display = self.field_name is not None
+            if self.field_name is not None:
+                field_name.update(labelled_value("Header", self.field_name))
+            yield field_name
 
-        with Grid(classes="record-diagnostics"):
-            yield Static(
-                labelled_value("Deserializer", self._deserializer()),
-                classes="record-diagnostic record-deserializer",
-            )
-            yield Static(
-                labelled_value("Schema", self._schema()),
-                classes="record-diagnostic record-schema",
-            )
-            yield Static(
-                labelled_value("Size", format_payload_size(self.payload_size)),
-                classes="record-diagnostic record-size",
-            )
+            with Grid(classes="record-diagnostics"):
+                yield Static(
+                    labelled_value("Deserializer", self._deserializer()),
+                    classes="record-diagnostic record-deserializer",
+                )
+                yield Static(
+                    labelled_value("Schema", self._schema()),
+                    classes="record-diagnostic record-schema",
+                )
+                yield Static(
+                    labelled_value("Size", format_payload_size(self.payload_size)),
+                    classes="record-diagnostic record-size",
+                )
 
-        error = Static(self._error(), classes="record-error")
-        error.display = self.outcome.error is not None
-        yield error
+            error = Static(self._error(), classes="record-error")
+            error.display = self.outcome.error is not None
+            yield error
         yield Static(
             Text(
                 ("FALLBACK CONTENT" if self.outcome.error is not None else "CONTENT"),
@@ -317,10 +318,14 @@ class RecordFieldDetails(Container):
             ),
             classes="record-content-label",
         )
-        yield Static(
-            record_json_renderable(self.outcome.dict()["content"]),
-            classes="record-content",
-        )
+        with (
+            Container(classes="record-content-area"),
+            KaskadeScrollableContainer(classes="record-detail-scroll record-content-scroll"),
+        ):
+            yield Static(
+                record_json_renderable(self.outcome.dict()["content"]),
+                classes="record-content",
+            )
 
     def update_outcome(
         self,
@@ -354,6 +359,9 @@ class RecordFieldDetails(Container):
         )
         self.query_one(".record-content", Static).update(
             record_json_renderable(outcome.dict()["content"])
+        )
+        self.query_one(".record-field-metadata", KaskadeScrollableContainer).scroll_home(
+            animate=False
         )
 
 
@@ -474,10 +482,7 @@ class TopicScreen(HelpableModalScreen[Record]):
                         classes="record-metadata-cell",
                     )
             with TabbedContent(initial="key", id="record-details-tabs"):
-                with (
-                    TabPane("Key", id="key"),
-                    KaskadeScrollableContainer(classes="record-detail-scroll"),
-                ):
+                with TabPane("Key", id="key"):
                     yield RecordFieldDetails(
                         self.record.key_outcome(),
                         payload_size=(
@@ -485,10 +490,7 @@ class TopicScreen(HelpableModalScreen[Record]):
                         ),
                         id="record-key-details",
                     )
-                with (
-                    TabPane("Value", id="value"),
-                    KaskadeScrollableContainer(classes="record-detail-scroll"),
-                ):
+                with TabPane("Value", id="value"):
                     yield RecordFieldDetails(
                         self.record.value_outcome(),
                         payload_size=(
@@ -509,11 +511,9 @@ class TopicScreen(HelpableModalScreen[Record]):
                     empty = Static("No headers", id="record-headers-empty")
                     empty.display = not self.record.headers
                     yield empty
-                    header_scroll = KaskadeScrollableContainer(
-                        classes="record-detail-scroll record-header-scroll"
-                    )
-                    header_scroll.display = bool(self.record.headers)
-                    with header_scroll:
+                    header_details = Container(classes="record-header-details")
+                    header_details.display = bool(self.record.headers)
+                    with header_details:
                         header = self.record.headers[0] if self.record.headers else None
                         yield RecordFieldDetails(
                             (
@@ -530,8 +530,11 @@ class TopicScreen(HelpableModalScreen[Record]):
                             id="record-header-details",
                         )
                 with (
-                    TabPane("JSON", id="json"),
-                    KaskadeScrollableContainer(classes="record-detail-scroll"),
+                    TabPane("Export", id="json"),
+                    Container(classes="record-content-area"),
+                    KaskadeScrollableContainer(
+                        classes="record-detail-scroll record-content-scroll"
+                    ),
                 ):
                     yield Static(record_json_renderable(self.data), classes="record-json")
         yield Footer(compact=True)
@@ -580,7 +583,7 @@ class TopicScreen(HelpableModalScreen[Record]):
     def _refresh_headers(self) -> None:
         headers = self.query_one("#record-headers-list", KaskadeOptionList)
         empty = self.query_one("#record-headers-empty", Static)
-        details = self.query_one(".record-header-scroll", KaskadeScrollableContainer)
+        details = self.query_one(".record-header-details", Container)
         headers.clear_options()
         has_headers = bool(self.record.headers)
         headers.display = has_headers
@@ -608,9 +611,9 @@ class TopicScreen(HelpableModalScreen[Record]):
             payload_size=len(header.value) if header.value is not None else None,
             field_name=header.key,
         )
-        self.query_one(".record-header-scroll", KaskadeScrollableContainer).scroll_home(
-            animate=False
-        )
+        self.query_one(
+            "#record-header-details .record-content-scroll", KaskadeScrollableContainer
+        ).scroll_home(animate=False)
 
     def action_previous_record(self) -> None:
         self._show_record(self.record_index - 1)

--- a/kaskade/consumer.py
+++ b/kaskade/consumer.py
@@ -246,6 +246,18 @@ class RecordFieldDetails(Container):
         self.payload_size = payload_size
         self.field_name = field_name
 
+    def _header_summary(self) -> Text:
+        summary = labelled_value("Header", self.field_name or "")
+        summary.append(f" · {format_payload_size(self.payload_size)}", style="muted")
+        return summary
+
+    def _content_label(self) -> Text:
+        if self.payload_size is None:
+            label = "No Content (Null)"
+        else:
+            label = "FALLBACK CONTENT" if self.outcome.error is not None else "CONTENT"
+        return Text(label, style="muted")
+
     def _deserializer(self) -> str:
         parts = [self.outcome.requested.name]
         if self.outcome.schema is not None:
@@ -291,10 +303,12 @@ class RecordFieldDetails(Container):
             field_name = Static(classes="record-field-name")
             field_name.display = self.field_name is not None
             if self.field_name is not None:
-                field_name.update(labelled_value("Header", self.field_name))
+                field_name.update(self._header_summary())
             yield field_name
 
-            with Grid(classes="record-diagnostics"):
+            diagnostics = Grid(classes="record-diagnostics")
+            diagnostics.display = self.field_name is None
+            with diagnostics:
                 yield Static(
                     labelled_value("Deserializer", self._deserializer()),
                     classes="record-diagnostic record-deserializer",
@@ -311,15 +325,11 @@ class RecordFieldDetails(Container):
             error = Static(self._error(), classes="record-error")
             error.display = self.outcome.error is not None
             yield error
-        yield Static(
-            Text(
-                ("FALLBACK CONTENT" if self.outcome.error is not None else "CONTENT"),
-                style="muted",
-            ),
-            classes="record-content-label",
-        )
+        yield Static(self._content_label(), classes="record-content-label")
+        content_area = Container(classes="record-content-area")
+        content_area.display = self.payload_size is not None
         with (
-            Container(classes="record-content-area"),
+            content_area,
             KaskadeScrollableContainer(classes="record-detail-scroll record-content-scroll"),
         ):
             yield Static(
@@ -340,7 +350,8 @@ class RecordFieldDetails(Container):
         name = self.query_one(".record-field-name", Static)
         name.display = field_name is not None
         if field_name is not None:
-            name.update(labelled_value("Header", field_name))
+            name.update(self._header_summary())
+        self.query_one(".record-diagnostics", Grid).display = field_name is None
         self.query_one(".record-deserializer", Static).update(
             labelled_value("Deserializer", self._deserializer())
         )
@@ -351,12 +362,8 @@ class RecordFieldDetails(Container):
         error = self.query_one(".record-error", Static)
         error.display = outcome.error is not None
         error.update(self._error())
-        self.query_one(".record-content-label", Static).update(
-            Text(
-                "FALLBACK CONTENT" if outcome.error is not None else "CONTENT",
-                style="muted",
-            )
-        )
+        self.query_one(".record-content-label", Static).update(self._content_label())
+        self.query_one(".record-content-area", Container).display = payload_size is not None
         self.query_one(".record-content", Static).update(
             record_json_renderable(outcome.dict()["content"])
         )
@@ -458,12 +465,15 @@ class TopicScreen(HelpableModalScreen[Record]):
     def _metadata_content(label: str, value: str) -> Text:
         return labelled_value(label, value)
 
+    def _header_options(self) -> list[Option]:
+        return [
+            Option(Text.assemble((f"{index + 1}  ", "muted"), header.key), id=str(index))
+            for index, header in enumerate(self.record.headers)
+        ]
+
     def _headers_list(self) -> KaskadeOptionList:
         headers = KaskadeOptionList(
-            *(
-                Option(header.key, id=str(index))
-                for index, header in enumerate(self.record.headers)
-            ),
+            *self._header_options(),
             id="record-headers-list",
             compact=True,
         )
@@ -590,10 +600,7 @@ class TopicScreen(HelpableModalScreen[Record]):
         empty.display = not has_headers
         details.display = has_headers
         if has_headers:
-            headers.add_options(
-                Option(header.key, id=str(index))
-                for index, header in enumerate(self.record.headers)
-            )
+            headers.add_options(self._header_options())
             headers.highlighted = 0
             header = self.record.headers[0]
             self.query_one("#record-header-details", RecordFieldDetails).update_outcome(

--- a/kaskade/models.py
+++ b/kaskade/models.py
@@ -207,6 +207,9 @@ class Topic:
     def group_members_count(self) -> int:
         return sum(group.members_count() for group in self.groups)
 
+    def group_partitions_count(self) -> int:
+        return sum(group.partitions_count() for group in self.groups)
+
     def replicas_count(self) -> int:
         return max((len(partition.replicas) for partition in self.partitions), default=0)
 

--- a/kaskade/styles.css
+++ b/kaskade/styles.css
@@ -221,7 +221,7 @@ TopicScreen #record-metadata {
     width: 100%;
     height: 5;
     grid-size: 4 1;
-    grid-columns: 2fr 1fr 1fr 2fr;
+    grid-columns: 1fr 1fr 1fr 2fr;
     grid-rows: 1fr;
     grid-gutter: 0;
     margin-bottom: 1;

--- a/kaskade/styles.css
+++ b/kaskade/styles.css
@@ -210,7 +210,7 @@ ChunkSizeScreen > OptionList:focus > .option-list--option-highlighted {
 
 TopicScreen > .record-details {
     border: $secondary;
-    width: 100;
+    width: 120;
     max-width: 95%;
     height: 90%;
     background: $background;
@@ -232,7 +232,7 @@ DescribeTopicScreen .topic-metadata-cell {
     width: 100%;
     height: 100%;
     border: solid $secondary 50%;
-    padding: 0 1;
+    padding: 0;
     text-wrap: wrap;
 }
 
@@ -288,7 +288,7 @@ TopicScreen .record-diagnostic {
     height: 100%;
     min-height: 5;
     border: solid $secondary 50%;
-    padding: 1;
+    padding: 0;
     text-wrap: wrap;
 }
 
@@ -298,7 +298,7 @@ TopicScreen .record-error {
     min-height: 5;
     border: solid $error;
     background: $error 15%;
-    padding: 1 2;
+    padding: 0;
     margin-bottom: 1;
     text-wrap: wrap;
 }
@@ -357,7 +357,7 @@ TopicScreen .record-json {
 
 DescribeTopicScreen > .topic-details {
     border: $secondary;
-    width: 95%;
+    width: 90%;
     height: 90%;
     background: $background;
     padding: 0 1;

--- a/kaskade/styles.css
+++ b/kaskade/styles.css
@@ -264,7 +264,33 @@ TopicScreen .record-detail-scroll > Static {
 
 TopicScreen RecordFieldDetails {
     width: 100%;
+    height: 100%;
+    padding: 0 1;
+    overflow: hidden;
+}
+
+TopicScreen .record-content-area {
+    height: 1fr;
+    overflow: hidden;
+}
+
+TopicScreen .record-content-scroll {
     height: auto;
+    max-height: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding: 0;
+    background: $panel-darken-1;
+}
+
+TopicScreen .record-content-scroll:focus {
+    background: $panel;
+}
+
+TopicScreen .record-field-metadata {
+    width: 100%;
+    height: auto;
+    max-height: 70%;
 }
 
 TopicScreen .record-field-name {
@@ -306,21 +332,21 @@ TopicScreen .record-error {
 TopicScreen .record-content-label {
     width: 100%;
     height: 1;
-    margin-bottom: 1;
 }
 
-TopicScreen .record-content {
+TopicScreen .record-content,
+TopicScreen .record-json {
     width: 100%;
     height: auto;
     min-height: 3;
-    background: $panel;
+    background: $panel-darken-1;
     padding: 1 2;
     text-wrap: wrap;
 }
 
 TopicScreen .record-detail-scroll:focus .record-content,
 TopicScreen .record-detail-scroll:focus .record-json {
-    background: $panel-lighten-1;
+    background: $panel;
 }
 
 TopicScreen .record-headers-layout {
@@ -342,17 +368,9 @@ TopicScreen #record-headers-empty {
     content-align: center middle;
 }
 
-TopicScreen .record-header-scroll {
+TopicScreen .record-header-details {
     width: 68%;
     height: 100%;
-}
-
-TopicScreen .record-json {
-    width: 100%;
-    height: auto;
-    min-height: 3;
-    background: $panel;
-    padding: 1 2;
 }
 
 DescribeTopicScreen > .topic-details {

--- a/tests/unit/tests_admin.py
+++ b/tests/unit/tests_admin.py
@@ -7,7 +7,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from confluent_kafka import KafkaException
 from textual.coordinate import Coordinate
-from textual.widgets import Collapsible, DataTable, Input, RadioButton, RadioSet, Static
+from textual.widgets import (
+    Collapsible,
+    DataTable,
+    Input,
+    RadioButton,
+    RadioSet,
+    Static,
+    TabbedContent,
+)
 
 from kaskade.admin import (
     CreateTopicScreen,
@@ -484,6 +492,47 @@ class TestUpdateTopic(unittest.IsolatedAsyncioTestCase):
 
 
 class TestDescribeTopic(unittest.IsolatedAsyncioTestCase):
+    async def test_displays_partition_offsets_and_lag_for_each_group_partition(self) -> None:
+        topic = Topic(
+            name="orders",
+            partitions=[Partition(id=0, leader=1, low=10, high=100)],
+            groups=[
+                Group(id="shipping", partitions=[GroupPartition(id=0, offset=75, high=100)]),
+                Group(id="billing", partitions=[GroupPartition(id=0, offset=100, high=100)]),
+            ],
+            records_state=MetricState.READY,
+            groups_state=MetricState.READY,
+        )
+        for theme in ("eva01-berserk", "eva01", "textual-light", "ansi-light"):
+            with self.subTest(theme=theme), patch("kaskade.admin.TopicService") as service:
+                configure_admin_service(service.return_value, {})
+                app = KaskadeAdmin({})
+                app.theme = theme
+                async with app.run_test(size=(100, 30)) as pilot:
+                    app.push_screen(DescribeTopicScreen(topic, ()))
+                    await pilot.pause()
+                    partitions = app.screen.query_one("#partitions-table", DataTable)
+                    self.assertEqual(
+                        ["ID", "Leader", "Earliest", "End", "Records", "ISRs", "Replicas"],
+                        [column.label.plain for column in partitions.ordered_columns],
+                    )
+                    self.assertEqual(
+                        ["0", "1", "10", "100", "90", "[]", "[]"], partitions.get_row_at(0)
+                    )
+                    await pilot.press("l", "l", "l")
+                    self.assertEqual("group-offsets", app.screen.query_one(TabbedContent).active)
+                    offsets = app.screen.query_one("#group-offsets-table", DataTable)
+                    self.assertEqual(
+                        ["Group", "Partition", "Committed", "End", "Lag"],
+                        [column.label.plain for column in offsets.ordered_columns],
+                    )
+                    self.assertEqual(["shipping", "0", "75", "100", "25"], offsets.get_row_at(0))
+                    self.assertEqual(["billing", "0", "100", "100", "0"], offsets.get_row_at(1))
+                    self.assertFalse(offsets.show_horizontal_scrollbar)
+                    await pilot.resize_terminal(60, 30)
+                    await pilot.pause()
+                    self.assertGreater(offsets.content_region.height, 0)
+
     async def test_prioritizes_identity_columns_and_reveals_truncated_cells(self) -> None:
         group_id = "apicurio-c994055a-very-long-consumer-group-identifier"
         coordinator_node = Node(
@@ -545,7 +594,8 @@ class TestDescribeTopic(unittest.IsolatedAsyncioTestCase):
                 await pilot.pause()
                 self.assertIsNone(groups.tooltip)
 
-                tabs.active = "group-members"
+                app.screen.query_one("Tabs").focus()
+                await pilot.press("l", "l")
                 await pilot.pause()
                 members = app.screen.query_one("#group-members-table", DataTable)
                 self.assertLess(

--- a/tests/unit/tests_consumer.py
+++ b/tests/unit/tests_consumer.py
@@ -37,6 +37,7 @@ from kaskade.deserializers import (
     DeserializationError,
     DeserializationResult,
     Deserializer,
+    JsonDeserializer,
     RegistrySchema,
     StringDeserializer,
 )
@@ -634,6 +635,52 @@ class TestRecordCopyActions(unittest.IsolatedAsyncioTestCase):
 
 
 class TestRecordDetailsTabs(unittest.IsolatedAsyncioTestCase):
+    async def test_distinguishes_absent_payloads_from_null_strings_and_empty_strings(self) -> None:
+        cases = (
+            (None, StringDeserializer(), None),
+            (b"null", StringDeserializer(), '"null"'),
+            (b"", StringDeserializer(), '""'),
+            (None, StringDeserializer(), None),
+            (b"null", JsonDeserializer(), "null"),
+        )
+        records = tuple(
+            Record(
+                topic="orders",
+                offset=index,
+                key=payload,
+                value=payload,
+                key_deserializer=deserializer,
+                value_deserializer=deserializer,
+                headers=[Header("source", payload, StringDeserializer())],
+            )
+            for index, (payload, deserializer, _) in enumerate(cases)
+        )
+        app = KaskadeApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            details = TopicScreen(records[0], records=records)
+            await app.push_screen(details)
+            for index, (payload, _, expected_content) in enumerate(cases):
+                if index:
+                    details.action_next_record()
+                for tab_id in ("key", "value", "headers"):
+                    details.query_one(Tabs).focus()
+                    details.query_one(TabbedContent).active = tab_id
+                    await pilot.pause()
+                    field = details.query_one(f"#{tab_id} RecordFieldDetails")
+                    area = field.query_one(".record-content-area")
+                    label = field.query_one(".record-content-label", Static).render().plain
+                    self.assertEqual(payload is not None, area.display)
+                    self.assertEqual("No Content (Null)" if payload is None else "CONTENT", label)
+                    if payload is not None:
+                        expected = (
+                            json.dumps(payload.decode())
+                            if tab_id == "headers"
+                            else expected_content
+                        )
+                        self.assertEqual(
+                            expected, field.query_one(".record-content", Static).content.text.plain
+                        )
+
     async def test_content_scrolls_independently_of_field_metadata(self) -> None:
         payload = ("long field content " * 200).encode()
         record = Record(
@@ -793,7 +840,7 @@ class TestRecordDetailsTabs(unittest.IsolatedAsyncioTestCase):
                 [tab.label_text for tab in details.query(Tab)],
             )
             self.assertEqual(
-                ["source", "source"],
+                ["1  source", "2  source"],
                 [
                     str(headers.get_option_at_index(index).prompt)
                     for index in range(headers.option_count)
@@ -823,20 +870,14 @@ class TestRecordDetailsTabs(unittest.IsolatedAsyncioTestCase):
             await pilot.pause()
             header_details = details.query_one("#record-header-details", RecordFieldDetails)
             self.assertEqual(
-                "HEADER\nsource",
+                "HEADER\nsource · 0.001 KB",
                 header_details.query_one(".record-field-name", Static).render().plain,
             )
-            self.assertEqual(
-                "DESERIALIZER\nSTRING",
-                header_details.query_one(".record-deserializer", Static).render().plain,
-            )
-            deserializer_content = header_details.query_one(".record-deserializer", Static).content
-            self.assertIsInstance(deserializer_content, Text)
-            self.assertEqual("muted", deserializer_content.spans[0].style)
-            self.assertEqual(
-                "SIZE\n0.001 KB",
-                header_details.query_one(".record-size", Static).render().plain,
-            )
+            self.assertFalse(header_details.query_one(".record-diagnostics", Grid).display)
+            header_summary = header_details.query_one(".record-field-name", Static)
+            self.assertEqual("", header_summary.styles.border_top[0])
+            self.assertIsInstance(header_summary.content, Text)
+            self.assertEqual("muted", header_summary.content.spans[-1].style)
             error = header_details.query_one(".record-error", Static)
             self.assertTrue(error.display)
             self.assertIn("ERROR\ninvalid UTF-8\nFallback: BYTES · HEX", error.render().plain)
@@ -856,8 +897,8 @@ class TestRecordDetailsTabs(unittest.IsolatedAsyncioTestCase):
             await pilot.pause()
             self.assertFalse(header_details.query_one(".record-error", Static).display)
             self.assertEqual(
-                "SIZE\n0.01 KB",
-                header_details.query_one(".record-size", Static).render().plain,
+                "HEADER\nsource · 0.01 KB",
+                header_details.query_one(".record-field-name", Static).render().plain,
             )
             self.assertEqual(
                 "CONTENT",
@@ -871,6 +912,7 @@ class TestRecordDetailsTabs(unittest.IsolatedAsyncioTestCase):
             tabs.active = "key"
             await pilot.pause()
             key_details = details.query_one("#record-key-details", RecordFieldDetails)
+            self.assertTrue(key_details.query_one(".record-diagnostics", Grid).display)
             self.assertEqual(
                 "DESERIALIZER\nBYTES · HEX",
                 key_details.query_one(".record-deserializer", Static).render().plain,
@@ -1033,9 +1075,10 @@ class TestRecordDetailsNavigation(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(details.query_one("#record-headers-empty", Static).display)
             value_details = details.query_one("#record-value-details", RecordFieldDetails)
             self.assertEqual(
-                "null",
-                value_details.query_one(".record-content", Static).content.text.plain,
+                "No Content (Null)",
+                value_details.query_one(".record-content-label", Static).render().plain,
             )
+            self.assertFalse(value_details.query_one(".record-content-area").display)
             self.assertEqual(
                 "SIZE\n—",
                 value_details.query_one(".record-size", Static).render().plain,

--- a/tests/unit/tests_consumer.py
+++ b/tests/unit/tests_consumer.py
@@ -10,9 +10,10 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 from confluent_kafka.serialization import MessageField
 from rich.text import Text
 from textual import events
+from textual.color import Color
 from textual.containers import Container, Grid
 from textual.coordinate import Coordinate
-from textual.widgets import DataTable, OptionList, Static, Tab, TabbedContent, TabPane
+from textual.widgets import DataTable, OptionList, Static, Tab, TabbedContent, TabPane, Tabs
 
 from kaskade.colors import NULL as NULL_STYLE
 from kaskade.colors import WARNING as WARNING_STYLE
@@ -44,7 +45,7 @@ from kaskade.models import Header, Record
 from kaskade.record_export import readable_json, record_filename
 from kaskade.themes import KaskadeApp
 from kaskade.unicodes import WARNING as WARNING_INDICATOR
-from kaskade.widgets import TableFrame
+from kaskade.widgets import KaskadeScrollableContainer, TableFrame
 
 
 class TestPayloadSizeFormatting(unittest.TestCase):
@@ -633,6 +634,85 @@ class TestRecordCopyActions(unittest.IsolatedAsyncioTestCase):
 
 
 class TestRecordDetailsTabs(unittest.IsolatedAsyncioTestCase):
+    async def test_content_scrolls_independently_of_field_metadata(self) -> None:
+        payload = ("long field content " * 200).encode()
+        record = Record(
+            topic="orders",
+            key=payload,
+            value=b"\xff" + payload,
+            key_deserialization=Deserialization.STRING,
+            value_deserialization=Deserialization.STRING,
+            key_deserializer=StringDeserializer(),
+            value_deserializer=StringDeserializer(),
+            headers=[
+                Header("long-header", payload, StringDeserializer()),
+                Header("short-header", b"short", StringDeserializer()),
+            ],
+        )
+        for theme in ("eva01-berserk", "eva01", "textual-light", "ansi-light"):
+            for size in ((140, 40), (60, 24)):
+                with self.subTest(theme=theme, size=size):
+                    app = KaskadeApp()
+                    app.theme = theme
+                    async with app.run_test(size=size) as pilot:
+                        details = TopicScreen(record)
+                        await app.push_screen(details)
+                        for tab_id in ("key", "value", "headers"):
+                            details.query_one(Tabs).focus()
+                            details.query_one(TabbedContent).active = tab_id
+                            await pilot.pause()
+                            field = details.query_one(f"#{tab_id} RecordFieldDetails")
+                            metadata = field.query_one(".record-field-metadata")
+                            scroll = field.query_one(
+                                ".record-content-scroll", KaskadeScrollableContainer
+                            )
+                            diagnostics_region = field.query_one(".record-diagnostics").region
+                            self.assertGreater(scroll.content_region.height, 0)
+                            self.assertLessEqual(scroll.region.bottom, field.region.bottom)
+                            self.assertEqual(
+                                field.query_one(".record-content-area").region.height,
+                                scroll.region.height,
+                            )
+                            self.assertTrue(scroll.show_vertical_scrollbar)
+                            self.assertFalse(scroll.show_horizontal_scrollbar)
+                            self.assertLessEqual(
+                                scroll.virtual_size.width, scroll.scrollable_content_region.width
+                            )
+                            self.assertFalse(field.show_vertical_scrollbar)
+                            self.assertEqual(
+                                Color.parse(app.get_css_variables()["panel-darken-1"]),
+                                scroll.styles.background,
+                            )
+                            self.assertEqual(
+                                (1, 2, 1, 2), field.query_one(".record-content").styles.padding
+                            )
+                            scroll.focus()
+                            await pilot.press("G")
+                            await pilot.pause()
+                            self.assertGreater(scroll.scroll_y, 0)
+                            self.assertEqual(0, metadata.scroll_y)
+                            self.assertEqual(
+                                diagnostics_region, field.query_one(".record-diagnostics").region
+                            )
+                            if tab_id == "value":
+                                self.assertTrue(field.query_one(".record-error").display)
+                        headers = details.query_one("#record-headers-list", OptionList)
+                        headers.focus()
+                        headers.highlighted = 1
+                        await pilot.pause()
+                        self.assertEqual(0, scroll.scroll_y)
+                        content_height = field.query_one(".record-content").region.height
+                        available_height = field.query_one(".record-content-area").region.height
+                        self.assertEqual(
+                            min(content_height, available_height), scroll.region.height
+                        )
+                        self.assertEqual(
+                            content_height > available_height, scroll.show_vertical_scrollbar
+                        )
+                        self.assertFalse(scroll.show_horizontal_scrollbar)
+                        if size[0] == 140:
+                            self.assertLess(scroll.region.height, available_height)
+
     @patch("kaskade.consumer.ConsumerService")
     async def test_displays_ordered_headers_and_complete_field_diagnostics(
         self, consumer_service: MagicMock
@@ -709,7 +789,7 @@ class TestRecordDetailsTabs(unittest.IsolatedAsyncioTestCase):
                 details.query_one("#record-metadata", Grid).styles.grid_size_columns,
             )
             self.assertEqual(
-                ["Key", "Value", "Headers [2]", "JSON"],
+                ["Key", "Value", "Headers [2]", "Export"],
                 [tab.label_text for tab in details.query(Tab)],
             )
             self.assertEqual(
@@ -933,7 +1013,7 @@ class TestRecordDetailsNavigation(unittest.IsolatedAsyncioTestCase):
                 details.query_one("#record-total-size", Static).render().plain,
             )
             self.assertEqual(
-                ["Key", "Value", "Headers [1]", "JSON"],
+                ["Key", "Value", "Headers [1]", "Export"],
                 [tab.label_text for tab in details.query(Tab)],
             )
             header_list = details.query_one("#record-headers-list", OptionList)

--- a/tests/unit/tests_themes.py
+++ b/tests/unit/tests_themes.py
@@ -784,6 +784,8 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                             topic="orders",
                             partition=0,
                             offset=1,
+                            key=b"key",
+                            value=b"value",
                             headers=[Header("long-header-key", b"value", StringDeserializer())],
                         )
                     )

--- a/tests/unit/tests_themes.py
+++ b/tests/unit/tests_themes.py
@@ -911,6 +911,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                         "Partitions [0]",
                         "Configurations [2]",
                         "Groups [0]",
+                        "Group Offsets [0]",
                         "Group Members [0]",
                     ],
                     [tab.label_text for tab in app.screen.query(Tab)],
@@ -921,9 +922,9 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 )
                 self.assertNotEqual("none", details.styles.border_top[0])
                 self.assertEqual("", tabs.styles.border_top[0])
-                self.assertEqual(4, len(app.screen.query(TabPane)))
-                self.assertEqual(4, len(app.screen.query(DataTable)))
-                self.assertEqual(4, len(detail_tables))
+                self.assertEqual(5, len(app.screen.query(TabPane)))
+                self.assertEqual(5, len(app.screen.query(DataTable)))
+                self.assertEqual(5, len(detail_tables))
                 self.assertTrue(all(not table.zebra_stripes for table in detail_tables))
                 self.assertEqual(
                     ["Name", "Value"],

--- a/tests/unit/tests_themes.py
+++ b/tests/unit/tests_themes.py
@@ -796,7 +796,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(app.screen.content_region.width, details.region.width)
                 self.assertEqual(app.current_theme.background, details.styles.background.hex)
                 self.assertEqual(
-                    ["Key", "Value", "Headers [1]", "JSON"],
+                    ["Key", "Value", "Headers [1]", "Export"],
                     [tab.label_text for tab in app.screen.query(Tab)],
                 )
                 self.assertEqual(4, len(app.screen.query(TabPane)))
@@ -815,54 +815,64 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(1, diagnostics.styles.grid_size_columns)
                 self.assertEqual(3, diagnostics.styles.grid_size_rows)
                 content = app.screen.query_one("#record-key-details .record-content", Static)
-                self.assertEqual(app.current_theme.panel, content.styles.background.hex)
+                content_panel = app.get_css_variables()["panel-darken-1"]
+                self.assertEqual(content_panel, content.styles.background.hex)
                 self.assertNotEqual(details.styles.background, content.styles.background)
 
                 key_scroll = app.screen.query_one(
                     "#key .record-detail-scroll", KaskadeScrollableContainer
                 )
-                key_scroll.focus()
+                await pilot.press("tab")
+                self.assertIs(key_scroll, app.screen.focused)
                 await pilot.pause()
-                focused_panel = app.get_css_variables()["panel-lighten-1"]
+                focused_panel = app.get_css_variables()["panel"]
                 self.assertEqual(focused_panel, content.styles.background.hex)
 
-                tabs.focus()
+                await pilot.press("tab")
+                self.assertIs(tabs, app.screen.focused)
                 await pilot.press("right")
                 self.assertEqual("value", app.screen.query_one(TabbedContent).active)
                 value_scroll = app.screen.query_one(
                     "#value .record-detail-scroll", KaskadeScrollableContainer
                 )
-                value_scroll.focus()
+                await pilot.press("tab")
+                self.assertIs(value_scroll, app.screen.focused)
                 await pilot.pause()
                 value_content = app.screen.query_one(
                     "#record-value-details .record-content", Static
                 )
                 self.assertEqual(focused_panel, value_content.styles.background.hex)
-                self.assertEqual(app.current_theme.panel, content.styles.background.hex)
+                self.assertEqual(content_panel, content.styles.background.hex)
 
+                tabs.focus()
                 app.screen.query_one(TabbedContent).active = "headers"
                 await pilot.pause()
                 header_list = app.screen.query_one("#record-headers-list", OptionList)
-                header_details = app.screen.query_one(
-                    ".record-header-scroll", KaskadeScrollableContainer
-                )
+                header_details = app.screen.query_one(".record-header-details", Container)
                 self.assertEqual(header_list.region.y, header_details.region.y)
                 self.assertLess(header_list.region.x, header_details.region.x)
-                header_details.focus()
+                await pilot.press("tab")
+                self.assertIs(header_list, app.screen.focused)
+                await pilot.press("tab")
+                self.assertIs(
+                    header_details.query_one(".record-content-scroll"), app.screen.focused
+                )
                 await pilot.pause()
                 header_content = app.screen.query_one(
                     "#record-header-details .record-content", Static
                 )
                 self.assertEqual(focused_panel, header_content.styles.background.hex)
 
+                tabs.focus()
                 app.screen.query_one(TabbedContent).active = "json"
                 await pilot.pause()
                 json_content = app.screen.query_one(".record-json", Static)
-                self.assertEqual(app.current_theme.panel, json_content.styles.background.hex)
+                self.assertEqual(content_panel, json_content.styles.background.hex)
                 json_scroll = app.screen.query_one(
                     "#json .record-detail-scroll", KaskadeScrollableContainer
                 )
-                json_scroll.focus()
+                await pilot.press("tab")
+                self.assertIs(json_scroll, app.screen.focused)
                 await pilot.pause()
                 self.assertEqual(focused_panel, json_content.styles.background.hex)
 


### PR DESCRIPTION
## Summary

Make Topic Details slightly narrower (95% to 90%) and give Record Details more room (100 to 120 columns). Remove padding from metadata, field diagnostics, and error boxes while preserving content padding.

Keep record content in its own panel so scrolling does not move the field diagnostics. Panels fit short content and use vertical scrolling with wrapping when content exceeds the available space. Use a darker shared background across Key, Value, Headers, and the renamed Export tab. Keyboard focus moves directly from tabs to content, with the header list included in Headers.

## Verification

- [x] `uv run --locked python -m scripts.analyze`
- [x] `uv run --locked python -m scripts.tests`
- [x] `uv run --locked python -m scripts.tests --e2e`
- [x] Screenshot generation and all pre-commit hooks
- [x] Headless layout tests across Eva01 Berserk, Eva01, Textual Light, and ANSI Light, at wide and narrow terminal sizes. Coverage includes long and short content, vertical-only overflow, fallback diagnostics, header selection, focus navigation, and matching panel colors.

## User-facing changes

Detail dialogs use the adjusted widths and tighter metadata spacing. Header, key, value, and export content use darker panels that fit their content and preserve padding. Metadata can scroll separately on very short terminals. The JSON tab is now labeled Export; the record data and export format are unchanged.

## Checklist

- [x] Tests cover the affected layout and focus behavior.
- [x] Usage documentation reflects the Export tab name.
- [x] No secrets or private infrastructure details are included.
- [x] The title follows Conventional Commits and is suitable for release notes.

Assisted-by: Codex GPT-6
