### PR TITLE
feat(consumer): show headers in compact zero-based table

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -196,9 +196,12 @@ Select a topic in Admin mode or a consumed record in Consumer mode, then press
 `y` to copy the topic name or readable record JSON. Record Details separates the
 key, value, ordered headers, and complete record JSON (Export) into tabs while
 keeping the total raw payload size, partition, offset, and timestamp visible.
-The topic remains in the border title. In that modal, `y` copies the active tab's headers array, key
-object, value object, or complete record object. Copy is also available in Topic
-Details, contextual Help, and Commands, but is omitted from the Footer.
+The Headers tab shows zero-based indices in a compact table and reveals a full
+header name in a tooltip when the name is truncated.
+The topic remains in the border title. In that modal, `y` copies the active
+tab's headers array, key object, value object, or complete record object. Copy
+is also available in Topic Details, contextual Help, and Commands, but is
+omitted from the Footer.
 
 The Consumer records table shows the same total raw message size in its Size
 column.

--- a/kaskade/admin.py
+++ b/kaskade/admin.py
@@ -20,7 +20,6 @@ from textual.widgets import (
     Input,
     RadioButton,
     RadioSet,
-    Static,
     TabbedContent,
     TabPane,
     Tabs,
@@ -46,7 +45,12 @@ from kaskade.themes import KaskadeApp
 from kaskade.timeouts import TimeoutConfig
 from kaskade.unicodes import APPROXIMATION
 from kaskade.utils import copy_text, make_it_async, notify_error
-from kaskade.widgets import KaskadeHeader, StretchyDataTable, TableFrame, labelled_value
+from kaskade.widgets import (
+    KaskadeHeader,
+    MetadataCell,
+    StretchyDataTable,
+    TableFrame,
+)
 
 REFRESH_TABLE_DELAY = 1
 FILTER_TOPICS_SHORTCUT = "/,ctrl+f"
@@ -225,6 +229,11 @@ class DeleteTopicScreen(HelpableModalScreen[bool]):
 class DescribeTopicScreen(HelpableModalScreen):
     BINDING_GROUP_TITLE = "Topic Details"
     AUTO_FOCUS = "Tabs"
+    HORIZONTAL_BREAKPOINTS = [  # noqa: RUF012
+        (0, "-compact"),
+        (50, "-narrow"),
+        (80, "-wide"),
+    ]
     BINDINGS: ClassVar[list[BindingType]] = modal_bindings(
         Binding(
             COPY_TOPIC_SHORTCUT,
@@ -274,8 +283,9 @@ class DescribeTopicScreen(HelpableModalScreen):
         with details:
             with Grid(id="topic-metadata"):
                 for metadata_id, label, value in self._metadata():
-                    yield Static(
-                        labelled_value(label, value),
+                    yield MetadataCell(
+                        label,
+                        value,
                         id=metadata_id,
                         classes="topic-metadata-cell",
                     )

--- a/kaskade/consumer.py
+++ b/kaskade/consumer.py
@@ -3,6 +3,7 @@ from inspect import isawaitable
 from typing import Any, ClassVar
 
 from confluent_kafka import KafkaException
+from rich.cells import cell_len
 from rich.text import Text
 from textual import work
 from textual.app import ComposeResult
@@ -102,6 +103,22 @@ class RecordDataTable(StretchyDataTable[str | Text]):
     def watch_hover_coordinate(self, old: Coordinate, value: Coordinate) -> None:
         super().watch_hover_coordinate(old, value)
         self.tooltip = self._cell_tooltips.get(value)
+
+
+class HeaderDataTable(StretchyDataTable[str | Text]):
+    """A compact header table that reveals truncated header names."""
+
+    def watch_hover_coordinate(self, old: Coordinate, value: Coordinate) -> None:
+        super().watch_hover_coordinate(old, value)
+        self.tooltip = None
+        if not self.is_valid_coordinate(value):
+            return
+        cell_key = self.coordinate_to_cell_key(value)
+        if cell_key.column_key.value != "name":
+            return
+        header_name = str(self.get_cell_at(value))
+        if cell_len(header_name) > self.columns[cell_key.column_key].width:
+            self.tooltip = header_name
 
 
 class FilterRecordScreen(HelpableModalScreen[RecordFilters]):
@@ -465,20 +482,25 @@ class TopicScreen(HelpableModalScreen[Record]):
     def _metadata_content(label: str, value: str) -> Text:
         return labelled_value(label, value)
 
-    def _header_options(self) -> list[Option]:
-        return [
-            Option(Text.assemble((f"{index + 1}  ", "muted"), header.key), id=str(index))
-            for index, header in enumerate(self.record.headers)
-        ]
-
-    def _headers_list(self) -> KaskadeOptionList:
-        headers = KaskadeOptionList(
-            *self._header_options(),
+    def _headers_table(self) -> HeaderDataTable:
+        headers = HeaderDataTable(
             id="record-headers-list",
-            compact=True,
+            show_header=False,
+            cursor_type="row",
         )
-        headers.highlighted = 0 if self.record.headers else None
+        max_header_index = max(
+            (len(record.headers) - 1 for record in self.records),
+            default=0,
+        )
+        index_width = len(str(max(0, max_header_index)))
+        headers.add_column("", key="index", width=index_width)
+        headers.add_column("", key="name", width=1, stretch=1)
+        self._add_header_rows(headers)
         return headers
+
+    def _add_header_rows(self, headers: HeaderDataTable) -> None:
+        for index, header in enumerate(self.record.headers):
+            headers.add_row(Text(str(index), style="muted"), header.key, key=str(index))
 
     def compose(self) -> ComposeResult:
         container = Container(classes="record-details")
@@ -515,7 +537,7 @@ class TopicScreen(HelpableModalScreen[Record]):
                     ),
                     Container(classes="record-headers-layout"),
                 ):
-                    headers = self._headers_list()
+                    headers = self._headers_table()
                     headers.display = bool(self.record.headers)
                     yield headers
                     empty = Static("No headers", id="record-headers-empty")
@@ -591,17 +613,17 @@ class TopicScreen(HelpableModalScreen[Record]):
             self.on_record_changed(record)
 
     def _refresh_headers(self) -> None:
-        headers = self.query_one("#record-headers-list", KaskadeOptionList)
+        headers = self.query_one("#record-headers-list", HeaderDataTable)
         empty = self.query_one("#record-headers-empty", Static)
         details = self.query_one(".record-header-details", Container)
-        headers.clear_options()
+        headers.clear()
         has_headers = bool(self.record.headers)
         headers.display = has_headers
         empty.display = not has_headers
         details.display = has_headers
         if has_headers:
-            headers.add_options(self._header_options())
-            headers.highlighted = 0
+            self._add_header_rows(headers)
+            headers.move_cursor(row=0)
             header = self.record.headers[0]
             self.query_one("#record-header-details", RecordFieldDetails).update_outcome(
                 header.value_outcome(),
@@ -609,10 +631,14 @@ class TopicScreen(HelpableModalScreen[Record]):
                 field_name=header.key,
             )
 
-    def on_option_list_option_highlighted(self, event: OptionList.OptionHighlighted) -> None:
-        if event.option_list.id != "record-headers-list" or event.option_id is None:
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        if (
+            event.data_table.id != "record-headers-list"
+            or event.row_key is None
+            or event.row_key.value is None
+        ):
             return
-        header = self.record.headers[int(event.option_id)]
+        header = self.record.headers[int(event.row_key.value)]
         self.query_one("#record-header-details", RecordFieldDetails).update_outcome(
             header.value_outcome(),
             payload_size=len(header.value) if header.value is not None else None,

--- a/kaskade/consumer.py
+++ b/kaskade/consumer.py
@@ -799,6 +799,15 @@ class ListRecords(Container):
 
         return rf"[{PRIMARY}]Records[/] \[[{PRIMARY}]{self.topic}[/]]{title_filter}\[[{PRIMARY}]{len(self.records)}[/]]"
 
+    def _get_subtitle(self) -> str:
+        group_id = getattr(self.consumer, "group_id", None)
+        description = (
+            f"Consumer Mode · Group {group_id}"
+            if isinstance(group_id, str) and group_id
+            else "Consumer Mode"
+        )
+        return rf"\[[{PRIMARY}]{description}[/]]"
+
     def compose(self) -> ComposeResult:
         table = RecordDataTable(id="records-table", classes="main-table")
         table.cursor_type = "row"
@@ -813,7 +822,7 @@ class ListRecords(Container):
 
         frame = TableFrame(table, id="records-frame", classes="kaskade-table")
         frame.border_title = self._get_title()
-        frame.border_subtitle = rf"\[[{PRIMARY}]Consumer Mode[/]]"
+        frame.border_subtitle = self._get_subtitle()
         yield frame
 
     async def on_unmount(self) -> None:
@@ -848,6 +857,7 @@ class ListRecords(Container):
         self.current_record = None
         self.refresh_bindings()
         self._update_table_title()
+        self.query_one("#records-frame", TableFrame).border_subtitle = self._get_subtitle()
         self.action_consume()
 
     def _update_table_title(self) -> None:

--- a/kaskade/consumer.py
+++ b/kaskade/consumer.py
@@ -47,6 +47,7 @@ from kaskade.widgets import (
     KaskadeHeader,
     KaskadeOptionList,
     KaskadeScrollableContainer,
+    MetadataCell,
     StretchyDataTable,
     TableFrame,
     labelled_value,
@@ -326,16 +327,19 @@ class RecordFieldDetails(Container):
             diagnostics = Grid(classes="record-diagnostics")
             diagnostics.display = self.field_name is None
             with diagnostics:
-                yield Static(
-                    labelled_value("Deserializer", self._deserializer()),
+                yield MetadataCell(
+                    "Deserializer",
+                    self._deserializer(),
                     classes="record-diagnostic record-deserializer",
                 )
-                yield Static(
-                    labelled_value("Schema", self._schema()),
+                yield MetadataCell(
+                    "Schema",
+                    self._schema(),
                     classes="record-diagnostic record-schema",
                 )
-                yield Static(
-                    labelled_value("Size", format_payload_size(self.payload_size)),
+                yield MetadataCell(
+                    "Size",
+                    format_payload_size(self.payload_size),
                     classes="record-diagnostic record-size",
                 )
 
@@ -369,12 +373,10 @@ class RecordFieldDetails(Container):
         if field_name is not None:
             name.update(self._header_summary())
         self.query_one(".record-diagnostics", Grid).display = field_name is None
-        self.query_one(".record-deserializer", Static).update(
-            labelled_value("Deserializer", self._deserializer())
-        )
-        self.query_one(".record-schema", Static).update(labelled_value("Schema", self._schema()))
-        self.query_one(".record-size", Static).update(
-            labelled_value("Size", format_payload_size(self.payload_size))
+        self.query_one(".record-deserializer", MetadataCell).update_value(self._deserializer())
+        self.query_one(".record-schema", MetadataCell).update_value(self._schema())
+        self.query_one(".record-size", MetadataCell).update_value(
+            format_payload_size(self.payload_size)
         )
         error = self.query_one(".record-error", Static)
         error.display = outcome.error is not None
@@ -478,10 +480,6 @@ class TopicScreen(HelpableModalScreen[Record]):
             ),
         )
 
-    @staticmethod
-    def _metadata_content(label: str, value: str) -> Text:
-        return labelled_value(label, value)
-
     def _headers_table(self) -> HeaderDataTable:
         headers = HeaderDataTable(
             id="record-headers-list",
@@ -508,8 +506,9 @@ class TopicScreen(HelpableModalScreen[Record]):
         with container:
             with Grid(id="record-metadata"):
                 for metadata_id, label, value in self._metadata():
-                    yield Static(
-                        self._metadata_content(label, value),
+                    yield MetadataCell(
+                        label,
+                        value,
                         id=metadata_id,
                         classes="record-metadata-cell",
                     )
@@ -591,7 +590,7 @@ class TopicScreen(HelpableModalScreen[Record]):
         details = self.query_one(".record-details", Container)
         details.border_title = self._title()
         for metadata_id, label, value in self._metadata():
-            self.query_one(f"#{metadata_id}", Static).update(self._metadata_content(label, value))
+            self.query_one(f"#{metadata_id}", MetadataCell).update_value(value)
         tabs = self.query_one(TabbedContent)
         headers_tab = tabs.get_tab("headers")
         assert headers_tab is not None

--- a/kaskade/services.py
+++ b/kaskade/services.py
@@ -110,13 +110,14 @@ class ConsumerService:
         self.started_at = perf_counter()
         self.assigned_at: float | None = None
         self._consumer_error: KafkaError | None = None
-        default_group_id = f"kaskade-{uuid.uuid4()}"
+        default_group_id = f"kaskade-{uuid.uuid4().hex[:8]}"
         consumer_config = kafka_config | {
             ENABLE_AUTO_COMMIT: False,
             MAX_POLL_INTERVAL_MS: MILLISECONDS_24H,
             "error_cb": self._on_consumer_error,
         }
         consumer_config.setdefault(GROUP_ID, default_group_id)
+        self.group_id = str(consumer_config[GROUP_ID])
         self.consumer = Consumer(consumer_config, logger=logger)
         try:
             self._start_consuming()

--- a/kaskade/styles.css
+++ b/kaskade/styles.css
@@ -410,7 +410,8 @@ Screen.-narrow > .record-filter,
 Screen.-narrow > Input,
 Screen.-narrow > OptionList,
 Screen.-narrow > .record-details,
-DescribeTopicScreen.-narrow > .topic-details {
+DescribeTopicScreen.-narrow > .topic-details,
+DescribeTopicScreen.-compact > .topic-details {
     width: 100%;
     max-width: 100%;
 }
@@ -433,6 +434,13 @@ DescribeTopicScreen.-narrow #topic-metadata {
     grid-size: 4 2;
     grid-columns: 1fr 1fr 1fr 1fr;
     grid-rows: 1fr 1fr;
+}
+
+DescribeTopicScreen.-compact #topic-metadata {
+    height: 15;
+    grid-size: 3 3;
+    grid-columns: 1fr 1fr 1fr;
+    grid-rows: 1fr 1fr 1fr;
 }
 
 HelpScreen.-narrow > #help-dialog {

--- a/kaskade/styles.css
+++ b/kaskade/styles.css
@@ -219,7 +219,7 @@ TopicScreen > .record-details {
 
 TopicScreen #record-metadata {
     width: 100%;
-    height: 5;
+    height: 4;
     grid-size: 4 1;
     grid-columns: 1fr 1fr 1fr 2fr;
     grid-rows: 1fr;
@@ -312,7 +312,7 @@ TopicScreen .record-diagnostics {
 TopicScreen .record-diagnostic {
     width: 100%;
     height: 100%;
-    min-height: 5;
+    min-height: 4;
     border: solid $secondary 50%;
     padding: 0;
     text-wrap: wrap;
@@ -383,7 +383,7 @@ DescribeTopicScreen > .topic-details {
 
 DescribeTopicScreen #topic-metadata {
     width: 100%;
-    height: 5;
+    height: 4;
     grid-size: 7 1;
     grid-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
     grid-rows: 1fr;
@@ -417,7 +417,7 @@ DescribeTopicScreen.-compact > .topic-details {
 }
 
 TopicScreen.-narrow #record-metadata {
-    height: 10;
+    height: 8;
     grid-size: 2 2;
     grid-columns: 1fr 1fr;
     grid-rows: 1fr 1fr;
@@ -430,14 +430,14 @@ TopicScreen.-narrow .record-diagnostics {
 }
 
 DescribeTopicScreen.-narrow #topic-metadata {
-    height: 10;
+    height: 8;
     grid-size: 4 2;
     grid-columns: 1fr 1fr 1fr 1fr;
     grid-rows: 1fr 1fr;
 }
 
 DescribeTopicScreen.-compact #topic-metadata {
-    height: 15;
+    height: 12;
     grid-size: 3 3;
     grid-columns: 1fr 1fr 1fr;
     grid-rows: 1fr 1fr 1fr;

--- a/kaskade/widgets.py
+++ b/kaskade/widgets.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 from typing import Any, ClassVar
 
+from rich.cells import cell_len
 from rich.text import Text, TextType
 from textual import events
 from textual.app import ComposeResult
@@ -21,6 +22,46 @@ def labelled_value(label: str, value: str) -> Text:
     content.append("\n")
     content.append(value)
     return content
+
+
+class MetadataCell(Static):
+    """A labelled value that reveals its label when space truncates it."""
+
+    ELLIPSIS_BREAKPOINT = 50
+
+    def __init__(self, label: str, value: str, **kwargs: Any) -> None:
+        self._metadata_label = label
+        self._metadata_value = value
+        super().__init__(labelled_value(label, value), **kwargs)
+
+    def _content_for_width(self, width: int) -> Text:
+        label = Text()
+        label.append(self._metadata_label.upper(), style="muted")
+        if width and self.screen.size.width < self.ELLIPSIS_BREAKPOINT:
+            label.truncate(width, overflow="ellipsis")
+        label.append("\n")
+        label.append(self._metadata_value)
+        return label
+
+    def _refresh_content(self) -> None:
+        width = self.content_region.width
+        self.update(self._content_for_width(width), layout=False)
+        self.tooltip = (
+            self._metadata_label
+            if (
+                width
+                and self.screen.size.width < self.ELLIPSIS_BREAKPOINT
+                and cell_len(self._metadata_label.upper()) > width
+            )
+            else None
+        )
+
+    def on_resize(self, _event: events.Resize) -> None:
+        self._refresh_content()
+
+    def update_value(self, value: str) -> None:
+        self._metadata_value = value
+        self._refresh_content()
 
 
 class KaskadeHeader(Horizontal):

--- a/kaskade/widgets.py
+++ b/kaskade/widgets.py
@@ -27,8 +27,6 @@ def labelled_value(label: str, value: str) -> Text:
 class MetadataCell(Static):
     """A labelled value that reveals its label when space truncates it."""
 
-    ELLIPSIS_BREAKPOINT = 50
-
     def __init__(self, label: str, value: str, **kwargs: Any) -> None:
         self._metadata_label = label
         self._metadata_value = value
@@ -37,7 +35,7 @@ class MetadataCell(Static):
     def _content_for_width(self, width: int) -> Text:
         label = Text()
         label.append(self._metadata_label.upper(), style="muted")
-        if width and self.screen.size.width < self.ELLIPSIS_BREAKPOINT:
+        if width:
             label.truncate(width, overflow="ellipsis")
         label.append("\n")
         label.append(self._metadata_value)
@@ -48,11 +46,7 @@ class MetadataCell(Static):
         self.update(self._content_for_width(width), layout=False)
         self.tooltip = (
             self._metadata_label
-            if (
-                width
-                and self.screen.size.width < self.ELLIPSIS_BREAKPOINT
-                and cell_len(self._metadata_label.upper()) > width
-            )
+            if width and cell_len(self._metadata_label.upper()) > width
             else None
         )
 

--- a/tests/unit/tests_admin.py
+++ b/tests/unit/tests_admin.py
@@ -640,7 +640,7 @@ class TestDescribeTopic(unittest.IsolatedAsyncioTestCase):
                 )
                 self.assertEqual(
                     [
-                        "PARTITIONS\n2",
+                        "PARTIT…\n2",
                         "REPLICAS\n3",
                         "IN SYNC\n2",
                         "GROUPS\n1",
@@ -652,6 +652,10 @@ class TestDescribeTopic(unittest.IsolatedAsyncioTestCase):
                         cell.render().plain
                         for cell in app.screen.query(".topic-metadata-cell").results(Static)
                     ],
+                )
+                self.assertEqual(
+                    "Partitions",
+                    app.screen.query_one("#topic-partitions", Static).tooltip,
                 )
 
     async def test_loads_configurations_before_opening_topic_details(self) -> None:

--- a/tests/unit/tests_consumer.py
+++ b/tests/unit/tests_consumer.py
@@ -1112,6 +1112,7 @@ class TestConsumptionCoordination(unittest.IsolatedAsyncioTestCase):
 
         consumer_service.return_value.consume = AsyncMock(side_effect=consume)
         consumer_service.return_value.aclose = AsyncMock()
+        consumer_service.return_value.group_id = "authorized-reader"
         app = KaskadeConsumer(
             "orders",
             {},
@@ -1132,6 +1133,7 @@ class TestConsumptionCoordination(unittest.IsolatedAsyncioTestCase):
                 self.assertTrue(table.loading)
                 self.assertFalse(frame.loading)
                 self.assertIn("Records", frame.border_title)
+                self.assertIn("Consumer Mode · Group authorized-reader", frame.border_subtitle)
                 self.assertNotEqual("", frame.styles.border_top[0])
                 self.assertEqual("", table.styles.border_top[0])
             finally:

--- a/tests/unit/tests_consumer.py
+++ b/tests/unit/tests_consumer.py
@@ -13,12 +13,13 @@ from textual import events
 from textual.color import Color
 from textual.containers import Container, Grid
 from textual.coordinate import Coordinate
-from textual.widgets import DataTable, OptionList, Static, Tab, TabbedContent, TabPane, Tabs
+from textual.widgets import DataTable, Static, Tab, TabbedContent, TabPane, Tabs
 
 from kaskade.colors import NULL as NULL_STYLE
 from kaskade.colors import WARNING as WARNING_STYLE
 from kaskade.configs import CONFLUENT
 from kaskade.consumer import (
+    HeaderDataTable,
     KaskadeConsumer,
     ListRecords,
     RecordDataTable,
@@ -743,9 +744,9 @@ class TestRecordDetailsTabs(unittest.IsolatedAsyncioTestCase):
                             )
                             if tab_id == "value":
                                 self.assertTrue(field.query_one(".record-error").display)
-                        headers = details.query_one("#record-headers-list", OptionList)
+                        headers = details.query_one("#record-headers-list", HeaderDataTable)
                         headers.focus()
-                        headers.highlighted = 1
+                        headers.move_cursor(row=1)
                         await pilot.pause()
                         self.assertEqual(0, scroll.scroll_y)
                         content_height = field.query_one(".record-content").region.height
@@ -823,7 +824,7 @@ class TestRecordDetailsTabs(unittest.IsolatedAsyncioTestCase):
             await pilot.pause()
             details = app.screen
             tabs = details.query_one(TabbedContent)
-            headers = details.query_one("#record-headers-list", OptionList)
+            headers = details.query_one("#record-headers-list", HeaderDataTable)
 
             self.assertEqual("key", tabs.active)
             self.assertEqual(
@@ -840,12 +841,14 @@ class TestRecordDetailsTabs(unittest.IsolatedAsyncioTestCase):
                 [tab.label_text for tab in details.query(Tab)],
             )
             self.assertEqual(
-                ["1  source", "2  source"],
+                [("0", "source"), ("1", "source")],
                 [
-                    str(headers.get_option_at_index(index).prompt)
-                    for index in range(headers.option_count)
+                    tuple(str(cell) for cell in headers.get_row_at(index))
+                    for index in range(headers.row_count)
                 ],
             )
+            self.assertFalse(headers.show_header)
+            self.assertEqual(1, headers.ordered_columns[0].width)
             self.assertEqual(
                 "TOTAL SIZE\n0.03 KB",
                 details.query_one("#record-total-size", Static).render().plain,
@@ -866,7 +869,7 @@ class TestRecordDetailsTabs(unittest.IsolatedAsyncioTestCase):
                 details.query_one("#record-timestamp", Static).render().plain,
             )
 
-            headers.highlighted = 1
+            headers.move_cursor(row=1)
             await pilot.pause()
             header_details = details.query_one("#record-header-details", RecordFieldDetails)
             self.assertEqual(
@@ -893,7 +896,7 @@ class TestRecordDetailsTabs(unittest.IsolatedAsyncioTestCase):
                 header_details.query_one(".record-content", Static).content.text.plain,
             )
 
-            headers.highlighted = 0
+            headers.move_cursor(row=0)
             await pilot.pause()
             self.assertFalse(header_details.query_one(".record-error", Static).display)
             self.assertEqual(
@@ -1058,9 +1061,9 @@ class TestRecordDetailsNavigation(unittest.IsolatedAsyncioTestCase):
                 ["Key", "Value", "Headers [1]", "Export"],
                 [tab.label_text for tab in details.query(Tab)],
             )
-            header_list = details.query_one("#record-headers-list", OptionList)
-            self.assertEqual(1, header_list.option_count)
-            self.assertEqual(0, header_list.highlighted)
+            header_list = details.query_one("#record-headers-list", HeaderDataTable)
+            self.assertEqual(1, header_list.row_count)
+            self.assertEqual(0, header_list.cursor_row)
             self.assertTrue(details.check_action("previous_record", ()))
             self.assertFalse(details.check_action("next_record", ()))
 

--- a/tests/unit/tests_services.py
+++ b/tests/unit/tests_services.py
@@ -399,7 +399,11 @@ class TestConsumerService(unittest.IsolatedAsyncioTestCase):
         )
         self.assertRegex(
             mock_class_consumer.call_args.args[0][GROUP_ID],
-            r"^kaskade-[0-9a-f-]+$",
+            r"^kaskade-[0-9a-f]{8}$",
+        )
+        self.assertEqual(
+            mock_class_consumer.call_args.args[0][GROUP_ID],
+            service.group_id,
         )
         consumer.list_topics.assert_called_once_with(
             "orders", timeout=service.timeouts.consumer_request
@@ -428,6 +432,7 @@ class TestConsumerService(unittest.IsolatedAsyncioTestCase):
             "authorized-reader",
             mock_class_consumer.call_args.args[0][GROUP_ID],
         )
+        self.assertEqual("authorized-reader", service.group_id)
 
         service.close()
         consumer.unsubscribe.assert_called_once_with()

--- a/tests/unit/tests_themes.py
+++ b/tests/unit/tests_themes.py
@@ -58,6 +58,7 @@ from kaskade.widgets import (
     KaskadeHeader,
     KaskadeOptionList,
     KaskadeScrollableContainer,
+    MetadataCell,
     StretchyDataTable,
     TableFrame,
 )
@@ -894,6 +895,40 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 await pilot.press("escape")
                 self.assertIs(records_table, app.screen.focused)
 
+    async def test_record_metadata_ellipsizes_labels_on_tiny_screens(self):
+        with patch("kaskade.consumer.ConsumerService") as consumer_service:
+            consumer_service.return_value.consume = AsyncMock(return_value=[])
+            app = KaskadeConsumer(
+                "orders",
+                {},
+                {},
+                {},
+                {},
+                Deserialization.STRING,
+                Deserialization.STRING,
+            )
+
+            async with app.run_test(size=(24, 24)) as pilot:
+                app.push_screen(
+                    TopicScreen(
+                        Record(
+                            topic="orders",
+                            partition=0,
+                            offset=1,
+                            key=b"key",
+                            value=b"value",
+                        )
+                    )
+                )
+                await pilot.pause()
+
+                total_size = app.screen.query_one("#record-total-size", MetadataCell)
+                deserializer = app.screen.query_one(".record-deserializer", MetadataCell)
+                self.assertTrue(total_size.render().plain.splitlines()[0].endswith("…"))
+                self.assertEqual("Total Size", total_size.tooltip)
+                self.assertEqual("DESERIALIZER", deserializer.render().plain.splitlines()[0])
+                self.assertIsNone(deserializer.tooltip)
+
     async def test_topic_details_use_native_tabs_and_a_contextual_footer(self):
         with patch("kaskade.admin.TopicService") as topic_service:
             configure_admin_service(topic_service.return_value, {})
@@ -997,6 +1032,40 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                     app.screen.query_one("#partitions-table", DataTable).content_region.height,
                     0,
                 )
+
+    async def test_topic_details_metadata_uses_three_columns_on_compact_screens(self):
+        with patch("kaskade.admin.TopicService") as topic_service:
+            configure_admin_service(topic_service.return_value, {})
+            app = KaskadeAdmin({})
+
+            async with app.run_test(size=(48, 30)) as pilot:
+                app.push_screen(DescribeTopicScreen(Topic(name="orders"), ()))
+                await pilot.pause()
+
+                metadata = app.screen.query_one("#topic-metadata", Grid)
+                cells = list(metadata.query(".topic-metadata-cell"))
+                partitions = app.screen.query_one("#topic-partitions", Static)
+                self.assertTrue(app.screen.has_class("-compact"))
+                self.assertEqual(3, metadata.styles.grid_size_columns)
+                self.assertEqual(3, metadata.styles.grid_size_rows)
+                self.assertEqual(cells[0].region.y, cells[2].region.y)
+                self.assertGreater(cells[3].region.y, cells[0].region.y)
+                self.assertGreaterEqual(partitions.content_region.width, len("PARTITIONS"))
+                self.assertIsNone(partitions.tooltip)
+
+    async def test_topic_details_metadata_ellipsizes_labels_on_tiny_screens(self):
+        with patch("kaskade.admin.TopicService") as topic_service:
+            configure_admin_service(topic_service.return_value, {})
+            app = KaskadeAdmin({})
+
+            async with app.run_test(size=(36, 30)) as pilot:
+                app.push_screen(DescribeTopicScreen(Topic(name="orders"), ()))
+                await pilot.pause()
+
+                partitions = app.screen.query_one("#topic-partitions", Static)
+                self.assertLess(partitions.content_region.width, len("PARTITIONS"))
+                self.assertTrue(partitions.render().plain.splitlines()[0].endswith("…"))
+                self.assertEqual("Partitions", partitions.tooltip)
 
     async def test_topic_details_help_excludes_ctrl_c_from_selected_text_copy(self):
         with patch("kaskade.admin.TopicService") as topic_service:

--- a/tests/unit/tests_themes.py
+++ b/tests/unit/tests_themes.py
@@ -814,10 +814,16 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 self.assertTrue(
                     all(cell.styles.border_top[0] == "solid" for cell in metadata_cells)
                 )
-                self.assertTrue(all(cell.content_region.height >= 2 for cell in metadata_cells))
+                self.assertTrue(all(cell.content_region.height == 2 for cell in metadata_cells))
                 diagnostics = app.screen.query_one(".record-diagnostics", Grid)
                 self.assertEqual(1, diagnostics.styles.grid_size_columns)
                 self.assertEqual(3, diagnostics.styles.grid_size_rows)
+                self.assertTrue(
+                    all(
+                        cell.content_region.height == 2
+                        for cell in diagnostics.query(".record-diagnostic")
+                    )
+                )
                 content = app.screen.query_one("#record-key-details .record-content", Static)
                 content_panel = app.get_css_variables()["panel-darken-1"]
                 self.assertEqual(content_panel, content.styles.background.hex)
@@ -954,6 +960,12 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(7, metadata.styles.grid_size_columns)
                 self.assertEqual(1, metadata.styles.grid_size_rows)
                 self.assertEqual(7, len(metadata.query(".topic-metadata-cell")))
+                self.assertTrue(
+                    all(
+                        cell.content_region.height == 2
+                        for cell in metadata.query(".topic-metadata-cell")
+                    )
+                )
                 self.assertEqual(
                     [
                         "Partitions [0]",
@@ -1026,6 +1038,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(app.screen.content_region.width, details.region.width)
                 self.assertEqual(4, metadata.styles.grid_size_columns)
                 self.assertEqual(2, metadata.styles.grid_size_rows)
+                self.assertTrue(all(cell.content_region.height == 2 for cell in cells))
                 self.assertEqual(cells[0].region.y, cells[3].region.y)
                 self.assertGreater(cells[4].region.y, cells[0].region.y)
                 self.assertGreater(
@@ -1048,6 +1061,7 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 self.assertTrue(app.screen.has_class("-compact"))
                 self.assertEqual(3, metadata.styles.grid_size_columns)
                 self.assertEqual(3, metadata.styles.grid_size_rows)
+                self.assertTrue(all(cell.content_region.height == 2 for cell in cells))
                 self.assertEqual(cells[0].region.y, cells[2].region.y)
                 self.assertGreater(cells[3].region.y, cells[0].region.y)
                 self.assertGreaterEqual(partitions.content_region.width, len("PARTITIONS"))

--- a/tests/unit/tests_themes.py
+++ b/tests/unit/tests_themes.py
@@ -37,6 +37,7 @@ from kaskade.configs import BOOTSTRAP_SERVERS
 from kaskade.consumer import (
     ChunkSizeScreen,
     FilterRecordScreen,
+    HeaderDataTable,
     KaskadeConsumer,
     ListRecords,
     TopicScreen,
@@ -849,8 +850,20 @@ class TestMainAppLayout(unittest.IsolatedAsyncioTestCase):
                 tabs.focus()
                 app.screen.query_one(TabbedContent).active = "headers"
                 await pilot.pause()
-                header_list = app.screen.query_one("#record-headers-list", OptionList)
+                header_list = app.screen.query_one("#record-headers-list", HeaderDataTable)
                 header_details = app.screen.query_one(".record-header-details", Container)
+                self.assertFalse(header_list.show_header)
+                self.assertLess(
+                    header_list.ordered_columns[0].width,
+                    header_list.ordered_columns[1].width,
+                )
+                self.assertEqual(
+                    "ellipsis",
+                    header_list._compute_row_renderables(0).cells[1].overflow,
+                )
+                header_list.hover_coordinate = Coordinate(0, 1)
+                await pilot.pause()
+                self.assertEqual("long-header-key", header_list.tooltip)
                 self.assertEqual(header_list.region.y, header_details.region.y)
                 self.assertLess(header_list.region.x, header_details.region.x)
                 await pilot.press("tab")

--- a/tests/unit/tests_widgets.py
+++ b/tests/unit/tests_widgets.py
@@ -1,10 +1,35 @@
 import unittest
+from pathlib import Path
 
 from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.widgets import OptionList
 
-from kaskade.widgets import KaskadeOptionList, StretchyDataTable
+from kaskade.themes import KaskadeApp
+from kaskade.widgets import KaskadeOptionList, MetadataCell, StretchyDataTable
+
+
+class TestMetadataCell(unittest.IsolatedAsyncioTestCase):
+    async def test_ellipsizes_only_the_label_and_exposes_its_tooltip(self):
+        class MetadataApp(KaskadeApp):
+            CSS_PATH = Path(__file__).parents[2] / "kaskade/styles.css"
+            CSS = "MetadataCell { width: 8; height: 4; }"
+
+            def compose(self) -> ComposeResult:
+                yield MetadataCell("Deserializer", "a value that may wrap")
+
+        app = MetadataApp()
+        async with app.run_test(size=(20, 8)) as pilot:
+            cell = app.query_one(MetadataCell)
+            await pilot.pause()
+
+            label, value = cell.render().plain.split("\n", maxsplit=1)
+            self.assertEqual("DESERIA…", label)
+            self.assertEqual("a value that may wrap", value)
+            self.assertEqual("Deserializer", cell.tooltip)
+
+            cell.update_value("updated value")
+            self.assertEqual("DESERIA…\nupdated value", cell.render().plain)
 
 
 class StretchyTableApp(App):


### PR DESCRIPTION
## Summary

- replace the record header option list with a headerless table
- display zero-based header indices in a compact column
- truncate long header names with an ellipsis and show the full name on hover
- document and test the updated behavior

## Verification

- UV_CACHE_DIR=/private/tmp/kaskade-uv-cache uv run --locked python -m scripts.analyze
- UV_CACHE_DIR=/private/tmp/kaskade-uv-cache uv run --locked python -m scripts.tests
- repository commit hooks, including unit and end-to-end tests

Assisted-by: Codex GPT-5